### PR TITLE
Bundle host audio helper runtime

### DIFF
--- a/companion/package.json
+++ b/companion/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "npm run build && electron .",
     "typecheck": "tsc -p tsconfig.main.json --noEmit && tsc -p tsconfig.json --noEmit",
-    "build:host-audio": "dotnet publish native/HostAudioHelper/HostAudioHelper.csproj -c Release -r win-x64 --self-contained false -o native/HostAudioHelper/bin/publish/win-x64",
+    "build:host-audio": "dotnet publish native/HostAudioHelper/HostAudioHelper.csproj -c Release -r win-x64 --self-contained true -o native/HostAudioHelper/bin/publish/win-x64",
     "build": "npm run build:host-audio && tsc -p tsconfig.main.json && vite build",
     "package:win": "npm run build && node scripts/package-win.mjs",
     "installer:win": "npm run build && electron-builder --win nsis --x64",

--- a/docs/development.md
+++ b/docs/development.md
@@ -131,10 +131,9 @@ Useful options:
 
 ## Host Helper Runtime
 
-The host audio helper is currently published with `--self-contained false`, so
-developer machines and end-user machines need a compatible .NET runtime
-available. If the project should ship without relying on a system .NET runtime,
-switch the helper publish step to a self-contained Windows build.
+The host audio helper is published as a self-contained Windows x64 build so end
+users do not need to install a separate .NET runtime. Developer machines still
+need the .NET SDK to build or publish the helper locally.
 
 ## Project Layout
 

--- a/tools/create-release-candidate.ps1
+++ b/tools/create-release-candidate.ps1
@@ -73,6 +73,16 @@ function Write-SourceNotice([string] $Path) {
   ) | Set-Content -LiteralPath $Path -Encoding UTF8
 }
 
+function Get-SourceMetadata {
+  $commit = Get-GitValue 'rev-parse HEAD'
+  $dirty = -not [string]::IsNullOrWhiteSpace((Get-GitValue 'status --porcelain' ''))
+  return [ordered]@{
+    sourceUrl = 'https://github.com/SundayMoments/DS5_Bridge'
+    sourceCommit = $commit
+    dirty = $dirty
+  }
+}
+
 function Assert-SemanticVersion([string] $Name, [string] $Version) {
   if ($Version -notmatch '^\d+\.\d+\.\d+$') {
     throw "$Name version must use MAJOR.MINOR.PATCH format. Found: $Version"
@@ -196,12 +206,14 @@ Invoke-Step 'Collect artifacts' {
     createdAt = (Get-Date).ToString('o')
     firmwareVersion = $firmwareVersion
     companionVersion = $companionVersion
-    source = $repoRoot
     artifacts = @(
       $firmwareName,
       $installerName,
       $portableName
     )
+  }
+  foreach ($entry in (Get-SourceMetadata).GetEnumerator()) {
+    $manifest[$entry.Key] = $entry.Value
   }
   if (-not $NoZip) {
     $manifest.artifacts += "$portableName.zip"


### PR DESCRIPTION
## Summary
- Publish the Windows HostAudioHelper as a self-contained win-x64 build so clean Windows installs do not need a separate .NET 9 runtime.
- Update developer docs to reflect that end users no longer need a system .NET runtime for the helper.

## Validation
- `npm run build:host-audio`
- `npm run typecheck`
- Installed the release candidate and validated headphone audio + microphone on a VMware Windows test environment.

Fixes #6