### PR TITLE
[codex] Add speaker gain control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,7 +208,7 @@ if(DS5_ENABLE_FEEDBACK_TRACE_REPORTS)
 endif()
 
 pico_set_program_name(ds5-bridge "ds5-bridge")
-pico_set_program_version(ds5-bridge "1.6.1")
+pico_set_program_version(ds5-bridge "1.6.2")
 
 if(DS5_ENABLE_FIRMWARE_LOGS)
     pico_enable_stdio_uart(ds5-bridge 1)

--- a/companion/src/main/bridge-service.test.ts
+++ b/companion/src/main/bridge-service.test.ts
@@ -88,6 +88,7 @@ type StatusOverrides = {
   controllerConnected?: boolean;
   batteryPercent?: number;
   speakerVolumePercent?: number;
+  speakerGainLevel?: number;
   idleDisconnectTimeoutMinutes?: number;
   settingsRevision?: number;
   uptimeSeconds?: number;
@@ -114,6 +115,7 @@ const FULL_REAPPLY_COMMANDS = [
   COMMAND_ID.SET_CLASSIC_RUMBLE_GAIN,
   COMMAND_ID.SET_CLASSIC_RUMBLE_V1,
   COMMAND_ID.SET_TRIGGER_EFFECT_INTENSITY,
+  COMMAND_ID.SET_SPEAKER_GAIN,
   COMMAND_ID.SET_SPEAKER_VOLUME,
   COMMAND_ID.SET_DUPLEX_ENABLED,
   COMMAND_ID.SET_MIC_VOLUME,
@@ -297,6 +299,7 @@ function statusReport(overrides: StatusOverrides = {}): number[] {
   report[48] = overrides.hostPersonaMode === 'xbox' ? 1 : overrides.hostPersonaMode === 'ds4' ? 2 : 0;
   report[49] = overrides.supportedHostPersonaModesMask ?? 0;
   report[51] = overrides.micMuted ? 1 : 0;
+  report[57] = overrides.speakerGainLevel ?? 4;
   return report;
 }
 
@@ -1154,6 +1157,24 @@ describe('BridgeService', () => {
     expect(command?.[9]).toBe(25);
     expect(snapshot.settings.speakerVolumePercent).toBe(25);
     expect(snapshot.status?.speakerVolumePercent).toBe(25);
+  });
+
+  it('sends speaker gain as a global pinned firmware amp setting', async () => {
+    const service = serviceFixture();
+    const device = new MockHidDevice();
+    device.status = statusReport({ controllerConnected: false, firmwareFlags: 0x05 });
+    hidMock.state.devicesList = [companionDeviceInfo()];
+    hidMock.state.openDevices.set('companion-path', device);
+
+    await poll(service);
+    const snapshot = await service.setSpeakerGainLevel(6);
+
+    const command = device.sentReports.at(-1);
+    expect(command?.[7]).toBe(COMMAND_ID.SET_SPEAKER_GAIN);
+    expect(command?.[9]).toBe(6);
+    expect(snapshot.settings.speakerGainLevel).toBe(6);
+    expect(snapshot.status?.speakerGainLevel).toBe(6);
+    expect(snapshot.settings.controllerProfiles[0]?.settings).not.toHaveProperty('speakerGainLevel');
   });
 
   it('stores audio reactive haptics settings and enables firmware DSP only for bridge output passthrough', async () => {

--- a/companion/src/main/bridge-service.ts
+++ b/companion/src/main/bridge-service.ts
@@ -2188,6 +2188,21 @@ export class BridgeService extends EventEmitter {
     return this.getSnapshot();
   }
 
+  async setSpeakerGainLevel(level: number): Promise<BridgeSnapshot> {
+    const value = Math.max(1, Math.min(7, Math.round(level)));
+    await this.sendCommand(COMMAND_ID.SET_SPEAKER_GAIN, value, {
+      expectSettingsRevisionChange: true
+    });
+    this.snapshot.settings = this.settingsStore.update({
+      speakerGainLevel: value
+    });
+    if (this.snapshot.status) {
+      this.snapshot.status.speakerGainLevel = value;
+    }
+    this.emitSnapshot();
+    return this.getSnapshot();
+  }
+
   async setSpeakerEnabled(enabled: boolean): Promise<BridgeSnapshot> {
     const settings = this.settingsStore.get();
     await this.setFirmwareSpeakerVolume(enabled ? settings.speakerVolumePercent : 0, true);
@@ -3542,6 +3557,9 @@ export class BridgeService extends EventEmitter {
   }
 
   private async applySpeakerSettings(settings: CompanionSettings, expectSettingsRevisionChange: boolean): Promise<void> {
+    await this.sendCommand(COMMAND_ID.SET_SPEAKER_GAIN, settings.speakerGainLevel, {
+      expectSettingsRevisionChange
+    });
     await this.setFirmwareSpeakerVolume(settings.speakerEnabled ? settings.speakerVolumePercent : 0, expectSettingsRevisionChange);
   }
 

--- a/companion/src/main/main.ts
+++ b/companion/src/main/main.ts
@@ -699,6 +699,7 @@ function registerIpc(service: BridgeService): void {
     service.setAdaptiveTriggersEnabled(value)
   ));
   ipcMain.handle('bridge:setSpeakerVolume', (_event, value: number) => service.setSpeakerVolume(value));
+  ipcMain.handle('bridge:setSpeakerGainLevel', (_event, value: number) => service.setSpeakerGainLevel(value));
   ipcMain.handle('bridge:setSpeakerEnabled', (_event, value: boolean) => service.setSpeakerEnabled(value));
   ipcMain.handle('bridge:setMicVolume', (_event, value: number) => service.setMicVolume(value));
   ipcMain.handle('bridge:setMicMute', (_event, value: boolean) => service.setMicMute(value));

--- a/companion/src/main/settings-store.test.ts
+++ b/companion/src/main/settings-store.test.ts
@@ -401,6 +401,17 @@ describe('SettingsStore', () => {
     expect(persistedSettings(userDataPath).speakerVolumePercent).toBe(45);
   });
 
+  it('keeps speaker gain global instead of storing it in controller profiles', () => {
+    const userDataPath = tempUserDataPath();
+    const store = new SettingsStore(userDataPath);
+
+    const updated = store.update({ speakerGainLevel: 6 });
+
+    expect(updated.speakerGainLevel).toBe(6);
+    expect(updated.controllerProfiles[0]?.settings).not.toHaveProperty('speakerGainLevel');
+    expect(persistedSettings(userDataPath).speakerGainLevel).toBe(6);
+  });
+
   it('persists audio haptics app-session sources', () => {
     const userDataPath = tempUserDataPath();
     const store = new SettingsStore(userDataPath);
@@ -468,6 +479,7 @@ describe('SettingsStore', () => {
       uiThemePreset: 'laserwave',
       lightbarColor: '#golden',
       speakerVolumePercent: 999,
+      speakerGainLevel: 99,
       idleDisconnectTimeoutMinutes: -10,
       controllerProfiles: [{
         id: DEFAULT_CONTROLLER_PROFILE_ID,
@@ -491,6 +503,7 @@ describe('SettingsStore', () => {
     expect(settings.uiThemePreset).toBe(DEFAULT_SETTINGS.uiThemePreset);
     expect(settings.lightbarColor).toBe(DEFAULT_SETTINGS.lightbarColor);
     expect(settings.speakerVolumePercent).toBe(100);
+    expect(settings.speakerGainLevel).toBe(7);
     expect(settings.idleDisconnectTimeoutMinutes).toBe(1);
     expect(settings.controllerProfiles[0]?.name).toBe('Default');
     expect(settings.controllerProfiles[0]?.settings.speakerVolumePercent).toBe(100);

--- a/companion/src/main/settings-store.ts
+++ b/companion/src/main/settings-store.ts
@@ -153,6 +153,7 @@ export const DEFAULT_SETTINGS: CompanionSettings = {
   triggerTestMode: DEFAULT_CONTROLLER_PROFILE_SETTINGS.triggerTestMode,
   speakerEnabled: DEFAULT_CONTROLLER_PROFILE_SETTINGS.speakerEnabled,
   speakerVolumePercent: DEFAULT_CONTROLLER_PROFILE_SETTINGS.speakerVolumePercent,
+  speakerGainLevel: 4,
   micVolumePercent: DEFAULT_CONTROLLER_PROFILE_SETTINGS.micVolumePercent,
   micMuted: DEFAULT_CONTROLLER_PROFILE_SETTINGS.micMuted,
   audioReactiveHapticsEnabled: DEFAULT_CONTROLLER_PROFILE_SETTINGS.audioReactiveHapticsEnabled,
@@ -893,6 +894,9 @@ function normalizeSettings(value: Partial<CompanionSettings> | null | undefined)
     speakerVolumePercent: Number.isFinite(value?.speakerVolumePercent)
       ? Math.max(0, Math.min(100, Math.round(value!.speakerVolumePercent!)))
       : DEFAULT_SETTINGS.speakerVolumePercent,
+    speakerGainLevel: Number.isFinite(value?.speakerGainLevel)
+      ? Math.max(1, Math.min(7, Math.round(value!.speakerGainLevel!)))
+      : DEFAULT_SETTINGS.speakerGainLevel,
     micVolumePercent: Number.isFinite(value?.micVolumePercent)
       ? Math.max(0, Math.min(100, Math.round(value!.micVolumePercent!)))
       : DEFAULT_SETTINGS.micVolumePercent,

--- a/companion/src/preload.ts
+++ b/companion/src/preload.ts
@@ -70,6 +70,9 @@ const api = {
     ipcRenderer.invoke('bridge:setAdaptiveTriggersEnabled', value)
   ),
   setSpeakerVolume: (value: number): Promise<BridgeSnapshot> => ipcRenderer.invoke('bridge:setSpeakerVolume', value),
+  setSpeakerGainLevel: (value: number): Promise<BridgeSnapshot> => (
+    ipcRenderer.invoke('bridge:setSpeakerGainLevel', value)
+  ),
   setSpeakerEnabled: (value: boolean): Promise<BridgeSnapshot> => ipcRenderer.invoke('bridge:setSpeakerEnabled', value),
   setMicVolume: (value: number): Promise<BridgeSnapshot> => ipcRenderer.invoke('bridge:setMicVolume', value),
   setMicMute: (value: boolean): Promise<BridgeSnapshot> => ipcRenderer.invoke('bridge:setMicMute', value),

--- a/companion/src/renderer/App.tsx
+++ b/companion/src/renderer/App.tsx
@@ -382,6 +382,15 @@ const HOST_PERSONA_OPTIONS: Array<[string, HostPersonaMode]> = [
   ['DualShock 4', 'ds4'],
   ['Xbox', 'xbox']
 ];
+const SPEAKER_GAIN_OPTIONS: Array<[string, number]> = [
+  ['1', 1],
+  ['2', 2],
+  ['3', 3],
+  ['4', 4],
+  ['5', 5],
+  ['6', 6],
+  ['7', 7]
+];
 const AUDIO_REACTIVE_HAPTICS_MODE_OPTIONS: Array<[string, AudioReactiveHapticsMode]> = [
   ['Mix', 'mix'],
   ['Replace', 'replace']
@@ -3442,6 +3451,9 @@ export function App() {
   const classicRumbleV1Enabled = Boolean(snapshot?.settings.classicRumbleV1Enabled);
   const activeHapticsFeatureEnabled = showClassicRumbleControl ? classicRumbleEnabled : hapticsEnabled;
   const speakerEnabled = Boolean(snapshot?.settings.speakerEnabled);
+  const speakerGainLevel = Math.max(1, Math.min(7, Math.round(
+    snapshot?.settings.speakerGainLevel ?? snapshot?.status?.speakerGainLevel ?? 4
+  )));
   const adaptiveTriggersEnabled = Boolean(snapshot?.settings.adaptiveTriggersEnabled);
   const lightbarEnabled = Boolean(snapshot?.settings.lightbarEnabled);
   const sleepKeybindEnabled = Boolean(snapshot?.settings.sleepKeybindEnabled);
@@ -4190,6 +4202,17 @@ export function App() {
     speakerVolumeEditingRef.current = true;
     setSpeakerVolumeValue(snappedValue);
     void commitSpeakerVolume(snappedValue);
+  }
+
+  function setSpeakerGainLevel(level: number) {
+    if (!snapshot) {
+      return;
+    }
+    const value = Math.max(1, Math.min(7, Math.round(level)));
+    if (value === snapshot.settings.speakerGainLevel) {
+      return;
+    }
+    void runQuietAction(() => window.bridge.setSpeakerGainLevel(value));
   }
 
   async function commitMicVolume(value = micVolumeValue) {
@@ -7047,20 +7070,42 @@ export function App() {
                   <h2>Audio</h2>
                   <p>{`Adjust controller ${outputControlLower} and microphone levels.`}</p>
                 </div>
-                <div className="audio-heading-controls">
-                  <div className="inline-switch">
-                    <span>Enabled</span>
-                    <button
-                      type="button"
-                      role="switch"
-                      aria-checked={audioEnabled}
-                      aria-label="Enable audio"
-                      className={`switch ${audioEnabled ? 'on' : ''}`}
-                      disabled={!controllerControlsAvailable || pendingAction !== null}
-                      onClick={toggleAudioEnabled}
-                    >
-                      <span />
-                    </button>
+                <div className="audio-heading-actions">
+                  <div className="chords-field chords-inline-field audio-speaker-gain-field">
+                    <span>Speaker Gain</span>
+                    <CustomSelect
+                      value={speakerGainLevel}
+                      options={SPEAKER_GAIN_OPTIONS}
+                      disabled={!controllerControlsAvailable || !speakerVolumeSupported || pendingAction !== null}
+                      ariaLabel="Speaker gain"
+                      className="audio-speaker-gain-select"
+                      closeOnSelect={true}
+                      onChange={setSpeakerGainLevel}
+                      renderValue={(_label, value) => (
+                        <span>{value}</span>
+                      )}
+                      renderOption={(label) => (
+                        <span className="speaker-gain-option">
+                          <strong>{label}</strong>
+                        </span>
+                      )}
+                    />
+                  </div>
+                  <div className="audio-heading-controls">
+                    <div className="inline-switch">
+                      <span>Enabled</span>
+                      <button
+                        type="button"
+                        role="switch"
+                        aria-checked={audioEnabled}
+                        aria-label="Enable audio"
+                        className={`switch ${audioEnabled ? 'on' : ''}`}
+                        disabled={!controllerControlsAvailable || pendingAction !== null}
+                        onClick={toggleAudioEnabled}
+                      >
+                        <span />
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/companion/src/renderer/styles.css
+++ b/companion/src/renderer/styles.css
@@ -3056,10 +3056,68 @@ button.overview-shortcut-chip {
   box-shadow: var(--shadow-panel);
 }
 
+.audio-heading-actions {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 14px;
+}
+
 .audio-heading-controls .inline-switch {
   position: relative;
   min-height: 36px;
   padding: 0;
+}
+
+.chords-inline-field.audio-speaker-gain-field {
+  width: max-content;
+  grid-template-columns: max-content 56px;
+  flex: 0 0 auto;
+}
+
+.chords-inline-field.audio-speaker-gain-field > span {
+  white-space: nowrap;
+}
+
+.chords-inline-field.audio-speaker-gain-field .audio-speaker-gain-select {
+  width: 56px;
+}
+
+.chords-inline-field.audio-speaker-gain-field .custom-select-button {
+  grid-template-columns: max-content 16px;
+  justify-content: center;
+  gap: 5px;
+  padding: 0 7px;
+}
+
+.chords-inline-field.audio-speaker-gain-field .custom-select-button > span {
+  font-size: 13px;
+  font-weight: 760;
+}
+
+.chords-inline-field.audio-speaker-gain-field .custom-select-button > svg {
+  width: 16px;
+  height: 16px;
+}
+
+.audio-speaker-gain-select .custom-select-menu button {
+  grid-template-columns: max-content 14px;
+  justify-content: center;
+  gap: 4px;
+  padding: 0 7px;
+}
+
+.speaker-gain-option {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+}
+
+.speaker-gain-option strong {
+  color: var(--text-control);
+  font-size: 12px;
+  font-weight: 760;
 }
 
 .inline-state-badge {

--- a/companion/src/shared/protocol.test.ts
+++ b/companion/src/shared/protocol.test.ts
@@ -128,6 +128,7 @@ describe('companion protocol', () => {
     report[48] = 2;
     report[49] = 0x07;
     report[51] = 1;
+    report[57] = 6;
     report[60] = 1;
     report[61] = 0x68;
     report[62] = MUTE_KEYBOARD_HOLD_FLAG | MUTE_KEYBOARD_CHORD_STARTER_FLAG | 0x02;
@@ -138,6 +139,7 @@ describe('companion protocol', () => {
     expect(status.controllerType).toBe('dualsense-edge');
     expect(status.batteryPercent).toBe(80);
     expect(status.hapticsGainPercent).toBe(150);
+    expect(status.speakerGainLevel).toBe(6);
     expect(status.settingsRevision).toBe(3);
     expect(status.firmwareFlags.companion).toBe(true);
     expect(status.firmwareFlags.dse).toBe(true);

--- a/companion/src/shared/protocol.ts
+++ b/companion/src/shared/protocol.ts
@@ -4,7 +4,7 @@ export const REPORT_LENGTH = 64;
 export const PAYLOAD_LENGTH = 63;
 export const MAGIC = 'DS5B';
 export const PROTOCOL_MAJOR = 1;
-export const PROTOCOL_MINOR = 15;
+export const PROTOCOL_MINOR = 16;
 
 export const REPORT_ID = {
   STATUS: 0x01,
@@ -86,7 +86,8 @@ export const COMMAND_ID = {
   SET_AUDIO_REACTIVE_HAPTICS: 0x22,
   SET_CHORD_BINDINGS: 0x23,
   SET_PLAYER_LED_ENABLED: 0x24,
-  SET_CLASSIC_RUMBLE_V1: 0x25
+  SET_CLASSIC_RUMBLE_V1: 0x25,
+  SET_SPEAKER_GAIN: 0x32
 } as const;
 
 export const ACK_RESULT = {
@@ -403,6 +404,7 @@ export interface BridgeStatusPayload {
   hapticsReady: boolean;
   hapticsGainPercent: number;
   speakerVolumePercent: number;
+  speakerGainLevel: number;
   lightbarColor: {
     red: number;
     green: number;
@@ -677,6 +679,7 @@ export function parseStatusReport(report: ArrayLike<number>): BridgeStatusPayloa
     hapticsReady: report[12] === 1,
     hapticsGainPercent: readU16(report, 13),
     speakerVolumePercent: readU16(report, 29),
+    speakerGainLevel: Math.max(1, Math.min(7, report[57] || 4)),
     lightbarColor: {
       red: report[31],
       green: report[32],

--- a/companion/src/shared/types.ts
+++ b/companion/src/shared/types.ts
@@ -42,6 +42,7 @@ export interface CompanionSettings {
   triggerTestMode: TriggerTestMode;
   speakerEnabled: boolean;
   speakerVolumePercent: number;
+  speakerGainLevel: number;
   micVolumePercent: number;
   micMuted: boolean;
   audioReactiveHapticsEnabled: boolean;

--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -67,7 +67,7 @@
 #define DS_OUTPUT_HEADPHONE_VOLUME_MAX 0x7f
 #define DS_OUTPUT_SPEAKER_VOLUME_MAX 0x64
 #define DS_OUTPUT_MIC_VOLUME_MAX 0x40
-#define DS_OUTPUT_AUDIO_FLAGS2_SPEAKER_PREAMP_GAIN 0x02
+#define DS_OUTPUT_AUDIO_FLAGS2_SPEAKER_PREAMP_GAIN 0x04
 #define DS_OUTPUT_LIGHTBAR_SETUP_LIGHT_OUT 0x02
 #define DS_TRIGGER_EFFECT_SIZE 11
 #define DS_TRIGGER_EFFECT_RIGHT_OFFSET 10
@@ -282,6 +282,7 @@ static uint32_t lightbar_restore_at_us = 0;
 static uint8_t state_report_seq = 0;
 static bool speaker_output_enabled = false;
 static bool speaker_output_headset_route = false;
+static uint8_t speaker_output_gain = DS_OUTPUT_AUDIO_FLAGS2_SPEAKER_PREAMP_GAIN;
 static uint8_t companion_mic_volume_percent = 100;
 static ControllerOutputRumbleStateMachine classic_rumble_state{};
 
@@ -899,12 +900,30 @@ static void send_speaker_output_state(bool enabled, bool headset_plugged) {
             report[3 + 1] = DS_OUTPUT_VALID_FLAG1_AUDIO_CONTROL2_ENABLE;
             report[3 + OUTPUT_PAYLOAD_SPEAKER_VOLUME_OFFSET] = DS_OUTPUT_SPEAKER_VOLUME_MAX;
             report[3 + OUTPUT_PAYLOAD_AUDIO_CONTROL_OFFSET] = DS_OUTPUT_AUDIO_FLAGS_OUTPUT_PATH_SPEAKER;
-            report[3 + OUTPUT_PAYLOAD_AUDIO_CONTROL2_OFFSET] = DS_OUTPUT_AUDIO_FLAGS2_SPEAKER_PREAMP_GAIN;
+            report[3 + OUTPUT_PAYLOAD_AUDIO_CONTROL2_OFFSET] = speaker_output_gain;
         }
     } else {
         report[3 + OUTPUT_PAYLOAD_AUDIO_CONTROL_OFFSET] = DS_OUTPUT_AUDIO_FLAGS_OUTPUT_PATH_HEADPHONES;
     }
     bt_write(report, sizeof(report));
+}
+
+static uint8_t normalize_speaker_output_gain(uint8_t gain) {
+    return std::min<uint8_t>(7, std::max<uint8_t>(1, gain));
+}
+
+void bt_set_speaker_output_gain(uint8_t gain) {
+    const uint8_t next_gain = normalize_speaker_output_gain(gain);
+    const bool changed = speaker_output_gain != next_gain;
+    speaker_output_gain = next_gain;
+    controller_output_state_set_speaker_gain(next_gain);
+    if (changed) {
+        bt_refresh_speaker_output();
+    }
+}
+
+uint8_t bt_speaker_output_gain() {
+    return speaker_output_gain;
 }
 
 void bt_set_speaker_output_enabled(bool enabled, bool headset_plugged, bool force) {

--- a/src/bt.h
+++ b/src/bt.h
@@ -57,6 +57,8 @@ void bt_set_lightbar_color(uint8_t red, uint8_t green, uint8_t blue, uint8_t bri
 void bt_set_player_led_enabled(bool enabled);
 void bt_set_mute_led(bool enabled);
 void bt_set_microphone_state(uint8_t volume_percent, bool muted, bool control_mute_led, bool mute_led);
+void bt_set_speaker_output_gain(uint8_t gain);
+uint8_t bt_speaker_output_gain();
 void bt_set_speaker_output_enabled(bool enabled, bool headset_plugged = false, bool force = false);
 void bt_rearm_speaker_output_route(bool headset_plugged);
 void bt_refresh_speaker_output();

--- a/src/companion.cpp
+++ b/src/companion.cpp
@@ -20,11 +20,11 @@ namespace {
 
 constexpr uint8_t kMagic[] = {'D', 'S', '5', 'B'};
 constexpr uint8_t kProtocolMajor = 1;
-constexpr uint8_t kProtocolMinor = 15;
+constexpr uint8_t kProtocolMinor = 16;
 constexpr uint8_t kProtocolMinSupportedMinor = 7;
 constexpr uint8_t kFirmwareMajor = 1;
 constexpr uint8_t kFirmwareMinor = 6;
-constexpr uint8_t kFirmwarePatch = 1;
+constexpr uint8_t kFirmwarePatch = 2;
 constexpr uint8_t kAudioReactiveHapticsModeMask = 0x7f;
 constexpr uint8_t kAudioReactiveHapticsSuppressClassicRumbleFlag = 0x80;
 constexpr uint8_t kTriangleButtonBit = 0x80;
@@ -69,6 +69,7 @@ constexpr uint32_t kMuteKeyboardChordWindowUs = 250000;
 constexpr uint32_t kMuteLedFlashDurationUs = 120000;
 constexpr uint32_t kClassicRumbleTestDurationUs = 650000;
 constexpr uint8_t kClassicRumbleTestAmplitude = 160;
+constexpr uint8_t kDefaultSpeakerOutputGain = 4;
 constexpr uint32_t kAdaptiveTriggerTestDurationUs = 2500000;
 constexpr uint32_t kPersistentTriggerReapplyIntervalUs = 500000;
 constexpr uint32_t kGameTriggerUpdateRecentUs = 2000000;
@@ -134,6 +135,7 @@ enum CommandId : uint8_t {
     CommandSetChordBindings = 0x23,
     CommandSetPlayerLedEnabled = 0x24,
     CommandSetClassicRumbleV1 = 0x25,
+    CommandSetSpeakerGain = 0x32,
 };
 
 enum AckResult : uint8_t {
@@ -751,6 +753,7 @@ void restore_defaults() {
     companion_mic_enabled = true;
     audio_set_mic_mute_led_passthrough(false);
     audio_set_mic_output_state(companion_mic_volume_percent, companion_mic_muted);
+    bt_set_speaker_output_gain(kDefaultSpeakerOutputGain);
     reset_button_remap();
     bt_set_mute_led(false);
     lightbar_override_enabled = false;
@@ -1562,6 +1565,7 @@ uint16_t build_status(uint8_t *buffer, uint16_t reqlen) {
     buffer[47] = static_cast<uint8_t>(host_persona_active());
     buffer[48] = supported_host_persona_mask();
     buffer[50] = companion_mic_muted ? 1 : 0;
+    buffer[56] = bt_speaker_output_gain();
     buffer[58] = lightbar_override_enabled ? 1 : 0;
     buffer[59] = mute_button_mode;
     buffer[60] = mute_keyboard_usage;
@@ -1845,6 +1849,16 @@ void handle_command(uint8_t const *buffer, uint16_t bufsize) {
                 set_ack(command_id, sequence, AckOk);
                 return;
             }
+
+        case CommandSetSpeakerGain:
+            if (value < 1 || value > 7) {
+                set_ack(command_id, sequence, AckInvalidValue);
+                return;
+            }
+            bt_set_speaker_output_gain(static_cast<uint8_t>(value));
+            settings_revision++;
+            set_ack(command_id, sequence, AckOk);
+            return;
 
         case CommandSetMicVolume:
             if (value > 100) {

--- a/src/controller_output_state.cpp
+++ b/src/controller_output_state.cpp
@@ -31,6 +31,10 @@ bool player_led_enabled = true;
 uint8_t cached_player_leds = 0;
 bool cached_player_leds_valid = false;
 
+uint8_t normalize_speaker_gain(uint8_t gain) {
+    return std::min<uint8_t>(7, std::max<uint8_t>(1, gain));
+}
+
 void clamp_speaker_volume() {
     if (state_data[kSpeakerVolumeOffset] > kSpeakerVolumeMax) {
         state_data[kSpeakerVolumeOffset] = kSpeakerVolumeMax;
@@ -372,13 +376,6 @@ void controller_output_state_apply_host_payload(uint8_t const *data, uint8_t len
     copy_payload_range_if_allowed(
         update,
         copy_len,
-        (update[kValidFlag1Offset] & kFlag1AudioControl2Enable) != 0,
-        kAudioControl2Offset,
-        1
-    );
-    copy_payload_range_if_allowed(
-        update,
-        copy_len,
         (update[kValidFlag1Offset] & kFlag1HapticLowPassFilterEnable) != 0,
         kHapticLowPassFilterOffset,
         1
@@ -470,6 +467,18 @@ void controller_output_state_set_player_led_enabled(bool enabled) {
     apply_current_player_led_policy(state_data);
 }
 
+void controller_output_state_set_speaker_gain(uint8_t gain) {
+    const uint8_t clamped = normalize_speaker_gain(gain);
+    state_data[kValidFlag1Offset] |= kFlag1AudioControl2Enable;
+    state_data[kAudioControl2Offset] = static_cast<uint8_t>(
+        (state_data[kAudioControl2Offset] & 0xF8) | clamped
+    );
+}
+
+uint8_t controller_output_state_speaker_gain() {
+    return normalize_speaker_gain(static_cast<uint8_t>(state_data[kAudioControl2Offset] & 0x07));
+}
+
 bool controller_output_state_copy_player_led_report(uint8_t *destination, uint16_t len) {
     if (destination == nullptr || len <= kPlayerLedsOffset) {
         return false;
@@ -515,7 +524,11 @@ void controller_output_state_copy_audio_snapshot(uint8_t *destination, bool head
     destination[kValidFlag0Offset] |= static_cast<uint8_t>(
         kFlag0AudioControlEnable | kFlag0SpeakerVolumeEnable
     );
+    destination[kValidFlag1Offset] |= kFlag1AudioControl2Enable;
     destination[kHeadphoneVolumeOffset] = kHeadphoneVolumeMax;
     destination[kSpeakerVolumeOffset] = kSpeakerVolumeMax;
     destination[kAudioControlOffset] = kAudioFlagsOutputPathSpeaker;
+    destination[kAudioControl2Offset] = static_cast<uint8_t>(
+        (destination[kAudioControl2Offset] & 0xF8) | controller_output_state_speaker_gain()
+    );
 }

--- a/src/controller_output_state.h
+++ b/src/controller_output_state.h
@@ -20,6 +20,8 @@ void controller_output_state_set_adaptive_trigger(
 );
 void controller_output_state_set_lightbar(uint8_t red, uint8_t green, uint8_t blue, uint8_t brightness_percent);
 void controller_output_state_set_player_led_enabled(bool enabled);
+void controller_output_state_set_speaker_gain(uint8_t gain);
+uint8_t controller_output_state_speaker_gain();
 bool controller_output_state_copy_player_led_report(uint8_t *destination, uint16_t len);
 void controller_output_state_copy_audio_snapshot(uint8_t *destination, bool headset_plugged);
 void controller_output_state_clear_triggers(uint8_t *payload);

--- a/tests/firmware/firmware_logic_tests.cpp
+++ b/tests/firmware/firmware_logic_tests.cpp
@@ -439,7 +439,7 @@ void output_state_audio_snapshot_routes_to_speaker_and_headphones_safely() {
     EXPECT_EQ(speaker[kMicVolumeOffset], 0);
     EXPECT_EQ(speaker[kMuteLedOffset], 0);
     EXPECT_EQ(speaker[kAudioControlOffset], kAudioFlagsOutputPathSpeaker);
-    EXPECT_EQ(speaker[kAudioControl2Offset], 0x03);
+    EXPECT_EQ(speaker[kAudioControl2Offset], 0x02);
 
     AudioSnapshot headset{};
     controller_output_state_copy_audio_snapshot(headset.data(), true);
@@ -449,7 +449,16 @@ void output_state_audio_snapshot_routes_to_speaker_and_headphones_safely() {
     EXPECT_EQ(headset[kHeadphoneVolumeOffset], kHeadphoneVolumeMax);
     EXPECT_EQ(headset[kSpeakerVolumeOffset], 0);
     EXPECT_EQ(headset[kAudioControlOffset], kAudioFlagsOutputPathHeadphones);
-    EXPECT_EQ(headset[kAudioControl2Offset], 0x03);
+    EXPECT_EQ(headset[kAudioControl2Offset], 0x02);
+
+    controller_output_state_set_speaker_gain(6);
+    controller_output_state_copy_audio_snapshot(speaker.data(), false);
+    EXPECT_EQ(speaker[kAudioControl2Offset], 0x06);
+
+    payload[kAudioControl2Offset] = 0x01;
+    controller_output_state_apply_host_payload(payload.data(), static_cast<uint8_t>(payload.size()));
+    controller_output_state_copy_audio_snapshot(speaker.data(), false);
+    EXPECT_EQ(speaker[kAudioControl2Offset], 0x06);
 }
 
 void output_state_audio_snapshot_preserves_adaptive_trigger_effects_and_motor_power() {


### PR DESCRIPTION
## Summary

Adds a global speaker gain setting for the companion app and firmware, exposes it in the Audio controls, and sends the new pinned firmware amp command during setting reapply. The firmware now reports the selected gain in status, protects the speaker preamp bits from host output overwrites, and bumps the firmware/program version to 1.6.2.

## Impact

Users can choose controller speaker gain levels 1-7 from the companion app. The setting is global rather than controller-profile scoped, and firmware output snapshots preserve the selected speaker gain.

## Commits

- 98ce02c Speaker Gain
- bd18848 bump firmware to 1.6.2

## Validation

- npm run typecheck
- npm run test:companion
- npm run test:firmware
- npm run test:native
- companion-enabled firmware build in build-firmware-1.6.2
