### PR TITLE
Fix Windows release firmware toolchain setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,20 @@ jobs:
         with:
           dotnet-version: 9.0.x
 
+      - name: Install firmware build dependencies
+        shell: pwsh
+        run: |
+          choco install ninja gnu-arm-embedded -y --no-progress
+
+          $chocolateyProfile = Join-Path $env:ChocolateyInstall 'helpers\chocolateyProfile.psm1'
+          if (Test-Path -LiteralPath $chocolateyProfile) {
+            Import-Module $chocolateyProfile
+            refreshenv
+          }
+
+          arm-none-eabi-gcc --version
+          ninja --version
+
       - name: Download Pico SDK
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary
- Installs Ninja and the Arm embedded GCC toolchain in the Windows release artifact job.
- Refreshes Chocolatey's environment and verifies `arm-none-eabi-gcc`/`ninja` before companion packaging runs.

## Why
The `v1.6.3` release artifact workflow published firmware and metadata, but the Windows companion job failed because `arm-none-eabi-gcc` and Ninja were not available on `windows-latest`.

## Validation
- `git diff --check`