### PR TITLE
Fix release workflow for nuke packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,16 @@ jobs:
         with:
           dotnet-version: 9.0.x
 
+      - name: Set up Arm GNU Toolchain
+        uses: carlosperate/arm-none-eabi-gcc-action@v1.12.3
+
+      - name: Install firmware build dependencies
+        shell: pwsh
+        run: |
+          choco install ninja -y --no-progress
+          arm-none-eabi-gcc --version
+          ninja --version
+
       - name: Download Pico SDK
         shell: pwsh
         run: |

--- a/tools/build-pico-universal-flash-nuke.ps1
+++ b/tools/build-pico-universal-flash-nuke.ps1
@@ -25,6 +25,23 @@ function Invoke-Checked {
   }
 }
 
+function Get-Sha256Hex {
+  param([string] $Path)
+
+  $stream = [System.IO.File]::OpenRead($Path)
+  try {
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    try {
+      $bytes = $sha256.ComputeHash($stream)
+      return [System.BitConverter]::ToString($bytes).Replace('-', '').ToLowerInvariant()
+    } finally {
+      $sha256.Dispose()
+    }
+  } finally {
+    $stream.Dispose()
+  }
+}
+
 Invoke-Checked @('cmake', '-S', $sourceDir, '-B', $rp2040Build, '-G', 'Ninja', '-DPICO_BOARD=pico', '-DCMAKE_BUILD_TYPE=Release')
 Invoke-Checked @('cmake', '--build', $rp2040Build, '--target', 'flash_nuke')
 Invoke-Checked @('cmake', '-S', $sourceDir, '-B', $rp2350Build, '-G', 'Ninja', '-DPICO_BOARD=pico2', '-DCMAKE_BUILD_TYPE=Release')
@@ -56,8 +73,7 @@ try {
 
 $item = Get-Item -LiteralPath $OutputPath
 $hashPath = "$OutputPath.sha256"
-$hash = Get-FileHash -LiteralPath $OutputPath -Algorithm SHA256
-$hashLower = $hash.Hash.ToLowerInvariant()
+$hashLower = Get-Sha256Hex $OutputPath
 Set-Content -LiteralPath $hashPath -Value "$hashLower  $($item.Name)" -Encoding ascii
 $hashSourcePath = Join-Path $repoRoot 'companion\src\main\pico-universal-flash-nuke-hash.ts'
 Set-Content -LiteralPath $hashSourcePath -Value @(


### PR DESCRIPTION
## Summary
- Adds the Arm GNU toolchain setup to the Windows release artifact job so companion packaging can build the bundled Pico Universal Flash Nuke UF2.
- Keeps Ninja installation in the Windows release job and verifies both `arm-none-eabi-gcc` and `ninja` before packaging.
- Replaces the nuke UF2 `Get-FileHash` call with a .NET SHA256 implementation so hash generation works in CI shells.

## Validation
- `v1.6.3b` prerelease workflow completed successfully.
- Firmware UF2, Windows installer, portable zip, and release metadata uploaded successfully on the beta release.