### PR TITLE
Add Waveshare RP2350B-Plus-W build target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -36,7 +36,7 @@ jobs:
       # tarball instead of the apt package.
       - name: Cache ARM toolchain
         id: cache-arm-toolchain
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.ARM_TOOLCHAIN_PATH }}
           key: ${{ runner.os }}-${{ runner.arch }}-arm-toolchain-${{ env.ARM_TOOLCHAIN_VERSION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ env:
   PICO_SDK_REF: 2.2.0
   TINYUSB_REF: 0.20.0
   PICO_SDK_PATH: ${{ github.workspace }}/pico-sdk
+  ARM_TOOLCHAIN_VERSION: 14.2.rel1
+  ARM_TOOLCHAIN_URL: https://developer.arm.com/-/media/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi.tar.xz
+  ARM_TOOLCHAIN_PATH: ${{ github.workspace }}/arm-toolchain
 
 jobs:
   build:
@@ -25,7 +28,34 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt update
-          sudo apt install -y cmake python3 build-essential gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib ninja-build
+          sudo apt install -y cmake python3 build-essential ninja-build
+
+      # The Ubuntu apt-packaged gcc-arm-none-eabi 13.2 (15:13.2.rel1-2)
+      # produces Waveshare RP2350B-Plus-W binaries with audible audio static
+      # that ARM's official toolchains do not exhibit. Use ARM's 14.2.Rel1
+      # tarball instead of the apt package.
+      - name: Cache ARM toolchain
+        id: cache-arm-toolchain
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.ARM_TOOLCHAIN_PATH }}
+          key: ${{ runner.os }}-${{ runner.arch }}-arm-toolchain-${{ env.ARM_TOOLCHAIN_VERSION }}
+
+      - name: Download ARM toolchain
+        if: steps.cache-arm-toolchain.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p "$ARM_TOOLCHAIN_PATH"
+          curl -fsSL "$ARM_TOOLCHAIN_URL" | sudo tar -xJ -C "$ARM_TOOLCHAIN_PATH" --strip-components=1
+          sudo chmod -R a+rX "$ARM_TOOLCHAIN_PATH"
+
+      - name: Add ARM toolchain to PATH
+        run: |
+          echo "$ARM_TOOLCHAIN_PATH/bin" >> "$GITHUB_PATH"
+
+      - name: Verify ARM toolchain
+        run: |
+          which arm-none-eabi-gcc
+          arm-none-eabi-gcc --version
 
       - name: Download Pico SDK
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,9 +49,26 @@ jobs:
           mkdir -p artifacts
           cp build/companion/ds5-bridge.uf2 artifacts/ds5-bridge-companion.uf2
 
+      - name: Build companion firmware (Waveshare RP2350B-Plus-W)
+        run: |
+          cmake -S . -B build/waveshare -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DPICO_SDK_PATH="$PICO_SDK_PATH" \
+            -DENABLE_COMPANION=ON \
+            -DWAVESHARE_RP2350B_PLUS_W_BUILD=ON
+          cmake --build build/waveshare --target ds5-bridge
+          cp build/waveshare/ds5-bridge.uf2 artifacts/ds5-bridge-companion-waveshare.uf2
+
       - name: Upload companion UF2 artifact
         uses: actions/upload-artifact@v7
         with:
           path: artifacts/ds5-bridge-companion.uf2
+          archive: false
+          if-no-files-found: error
+
+      - name: Upload Waveshare companion UF2 artifact
+        uses: actions/upload-artifact@v7
+        with:
+          path: artifacts/ds5-bridge-companion-waveshare.uf2
           archive: false
           if-no-files-found: error

--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -14,19 +14,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: companion/package-lock.json
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 9.0.x
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout release ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.RELEASE_TAG }}
           submodules: recursive
@@ -123,7 +123,7 @@ jobs:
 
     steps:
       - name: Checkout release ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.RELEASE_TAG }}
           submodules: recursive
@@ -221,7 +221,7 @@ jobs:
 
     steps:
       - name: Checkout release ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.RELEASE_TAG }}
           submodules: recursive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ env:
   PICO_SDK_REF: 2.2.0
   TINYUSB_REF: 0.20.0
   PICO_SDK_PATH: ${{ github.workspace }}/pico-sdk
+  ARM_TOOLCHAIN_VERSION: 14.2.rel1
+  ARM_TOOLCHAIN_URL: https://developer.arm.com/-/media/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi.tar.xz
+  ARM_TOOLCHAIN_PATH: ${{ github.workspace }}/arm-toolchain
   RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag_name }}
 
 permissions:
@@ -35,7 +38,34 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt update
-          sudo apt install -y cmake python3 build-essential gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib ninja-build
+          sudo apt install -y cmake python3 build-essential ninja-build
+
+      # The Ubuntu apt-packaged gcc-arm-none-eabi 13.2 (15:13.2.rel1-2)
+      # produces Waveshare RP2350B-Plus-W binaries with audible audio static
+      # that ARM's official toolchains do not exhibit. Use ARM's 14.2.Rel1
+      # tarball instead of the apt package, matching the CI build workflow.
+      - name: Cache ARM toolchain
+        id: cache-arm-toolchain
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.ARM_TOOLCHAIN_PATH }}
+          key: ${{ runner.os }}-${{ runner.arch }}-arm-toolchain-${{ env.ARM_TOOLCHAIN_VERSION }}
+
+      - name: Download ARM toolchain
+        if: steps.cache-arm-toolchain.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p "$ARM_TOOLCHAIN_PATH"
+          curl -fsSL "$ARM_TOOLCHAIN_URL" | sudo tar -xJ -C "$ARM_TOOLCHAIN_PATH" --strip-components=1
+          sudo chmod -R a+rX "$ARM_TOOLCHAIN_PATH"
+
+      - name: Add ARM toolchain to PATH
+        run: |
+          echo "$ARM_TOOLCHAIN_PATH/bin" >> "$GITHUB_PATH"
+
+      - name: Verify ARM toolchain
+        run: |
+          which arm-none-eabi-gcc
+          arm-none-eabi-gcc --version
 
       - name: Download Pico SDK
         run: |
@@ -70,6 +100,16 @@ jobs:
           cmake --build build/companion --target ds5-bridge
           mkdir -p artifacts
           cp build/companion/ds5-bridge.uf2 "artifacts/DS5-Bridge-Firmware-v${FIRMWARE_VERSION}.uf2"
+
+      - name: Build companion firmware (Waveshare RP2350B-Plus-W)
+        run: |
+          cmake -S . -B build/waveshare -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DPICO_SDK_PATH="$PICO_SDK_PATH" \
+            -DENABLE_COMPANION=ON \
+            -DWAVESHARE_RP2350B_PLUS_W_BUILD=ON
+          cmake --build build/waveshare --target ds5-bridge
+          cp build/waveshare/ds5-bridge.uf2 "artifacts/DS5-Bridge-Firmware-Waveshare-v${FIRMWARE_VERSION}.uf2"
 
       - name: Upload firmware to release
         env:
@@ -225,6 +265,7 @@ jobs:
             companionVersion = $companionVersion
             artifacts = @(
               "DS5-Bridge-Firmware-v$firmwareVersion.uf2",
+              "DS5-Bridge-Firmware-Waveshare-v$firmwareVersion.uf2",
               "DS5-Bridge-Companion-Setup-v$companionVersion.exe",
               "DS5-Bridge-Companion-Portable-v$companionVersion-win32-x64.zip"
             )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,14 +129,14 @@ jobs:
           submodules: recursive
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: companion/package-lock.json
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 9.0.x
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,17 @@ if (EXISTS ${picoVscode})
     include(${picoVscode})
 endif ()
 # ====================================================================================
-set(PICO_BOARD pico2_w CACHE STRING "Board type")
+option(WAVESHARE_RP2350B_PLUS_W_BUILD "Build for Waveshare RP2350B-Plus-W (USB-C, 16MB flash, RM2 wireless)" OFF)
+
+if (WAVESHARE_RP2350B_PLUS_W_BUILD)
+    set(PICO_BOARD waveshare_rp2350b_plus_w CACHE STRING "Board type")
+    # Waveshare board header is not in upstream pico-sdk; ship it here and
+    # tell the SDK to search this directory when resolving PICO_BOARD.
+    list(APPEND PICO_BOARD_HEADER_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/boards/headers")
+else ()
+    set(PICO_BOARD pico2_w CACHE STRING "Board type")
+endif ()
+message(STATUS "ds5-bridge board target -- PICO_BOARD=${PICO_BOARD}")
 set(SYS_CLOCK_KHZ_VALUE 150000 CACHE STRING "RP2350 system clock in kHz")
 set(CYW43_PIO_CLOCK_DIV_VALUE 2 CACHE STRING "CYW43 PIO clock divider")
 

--- a/boards/build_waveshare_rp2350b_plus_w.sh
+++ b/boards/build_waveshare_rp2350b_plus_w.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Convenience build script for the Waveshare RP2350B-Plus-W target.
+#
+# Requires:
+#   - ARM toolchain (arm-none-eabi-gcc)
+#   - Ninja
+#   - A pico-sdk checkout pinned to 2.2.0 with TinyUSB checked out to 0.20.0.
+#     If you don't already have one, see the README for setup. By default this
+#     script uses PICO_SDK_PATH from the environment.
+#
+# Usage:
+#   ./boards/build_waveshare_rp2350b_plus_w.sh [Release|Debug]   # default: Release
+
+set -euo pipefail
+
+BUILD_TYPE="${1:-Release}"
+BUILD_DIR="build/waveshare"
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+if [[ -z "${PICO_SDK_PATH:-}" ]]; then
+    echo "PICO_SDK_PATH is not set. Set it to a pico-sdk checkout pinned to 2.2.0+TinyUSB 0.20.0." >&2
+    exit 1
+fi
+
+cd "${PROJECT_ROOT}"
+cmake -S . -B "${BUILD_DIR}" -G Ninja \
+    -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+    -DWAVESHARE_RP2350B_PLUS_W_BUILD=ON \
+    -DPICO_SDK_PATH="${PICO_SDK_PATH}"
+cmake --build "${BUILD_DIR}" --target ds5-bridge
+
+echo
+echo "Build complete. UF2 at:"
+echo "  ${PROJECT_ROOT}/${BUILD_DIR}/ds5-bridge.uf2"

--- a/boards/headers/waveshare_rp2350b_plus_w.h
+++ b/boards/headers/waveshare_rp2350b_plus_w.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2024 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+// This header may be included by other board headers as "boards/waveshare_rp2350_plus_w.h"
+
+#ifndef _BOARDS_WAVESHARE_RP2350B_PLUS_W
+#define _BOARDS_WAVESHARE_RP2350B_PLUS_W
+
+pico_board_cmake_set(PICO_PLATFORM, rp2350)
+pico_board_cmake_set(PICO_CYW43_SUPPORTED, 1)
+pico_board_cmake_set(PICO_DEFAULT_BOOT_STAGE2, boot2_w25q080)
+
+// For board detection
+#define WAVESHARE_RP2350B_PLUS_W
+
+// --- RP2350 VARIANT ---
+#define PICO_RP2350A 0
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 0
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 1
+#endif
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 4
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 5
+#endif
+
+// --- SPI ---
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 18
+#endif
+#ifndef PICO_DEFAULT_SPI_TX_PIN
+#define PICO_DEFAULT_SPI_TX_PIN 19
+#endif
+#ifndef PICO_DEFAULT_SPI_RX_PIN
+#define PICO_DEFAULT_SPI_RX_PIN 16
+#endif
+#ifndef PICO_DEFAULT_SPI_CSN_PIN
+#define PICO_DEFAULT_SPI_CSN_PIN 17
+#endif
+
+// --- FLASH ---
+
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+// pico_cmake_set_default PICO_FLASH_SIZE_BYTES = (4 * 1024 * 1024)
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (16 * 1024 * 1024)
+#endif
+// Drive high to force power supply into PWM mode (lower ripple on 3V3 at light loads)
+// note the SMSP mode pin is on WL_GPIO1
+
+#ifndef CYW43_WL_GPIO_COUNT
+#define CYW43_WL_GPIO_COUNT 3
+#endif
+
+#ifndef CYW43_WL_GPIO_LED_PIN
+#define CYW43_WL_GPIO_LED_PIN 0
+#endif
+
+// The GPIO Pin used to monitor VSYS. Typically you would use this with ADC.
+// There is an example in adc/read_vsys in pico-examples.
+#ifndef PICO_VSYS_PIN
+#define PICO_VSYS_PIN 46
+#endif
+
+// pico_cmake_set_default PICO_RP2350_A2_SUPPORTED = 1
+#ifndef PICO_RP2350_A2_SUPPORTED
+#define PICO_RP2350_A2_SUPPORTED 1
+#endif
+
+// cyw43 SPI pins can't be changed at runtime
+#ifndef CYW43_PIN_WL_DYNAMIC
+#define CYW43_PIN_WL_DYNAMIC 0
+#endif
+
+// gpio pin to power up the cyw43 chip
+#ifndef CYW43_DEFAULT_PIN_WL_REG_ON
+#define CYW43_DEFAULT_PIN_WL_REG_ON 36ULL
+#endif
+
+// gpio pin for spi data out to the cyw43 chip
+#ifndef CYW43_DEFAULT_PIN_WL_DATA_OUT
+#define CYW43_DEFAULT_PIN_WL_DATA_OUT 37ULL
+#endif
+
+// gpio pin for spi data in from the cyw43 chip
+#ifndef CYW43_DEFAULT_PIN_WL_DATA_IN
+#define CYW43_DEFAULT_PIN_WL_DATA_IN 37ULL
+#endif
+
+// gpio (irq) pin for the irq line from the cyw43 chip
+#ifndef CYW43_DEFAULT_PIN_WL_HOST_WAKE
+#define CYW43_DEFAULT_PIN_WL_HOST_WAKE 37ULL
+#endif
+
+// gpio pin for the spi clock line to the cyw43 chip
+#ifndef CYW43_DEFAULT_PIN_WL_CLOCK
+#define CYW43_DEFAULT_PIN_WL_CLOCK 39ULL
+#endif
+
+// gpio pin for the spi chip select to the cyw43 chip
+#ifndef CYW43_DEFAULT_PIN_WL_CS
+#define CYW43_DEFAULT_PIN_WL_CS 38ULL
+#endif
+
+#endif

--- a/docs/development.md
+++ b/docs/development.md
@@ -46,6 +46,20 @@ The resulting firmware is:
 build/companion/ds5-bridge.uf2
 ```
 
+### Waveshare RP2350B-Plus-W
+
+The Waveshare RP2350B-Plus-W (USB-C, 16MB flash, RM2 wireless) wires the
+CYW43/RM2 module to different RP2350 GPIOs than the Pico 2 W, so it needs its
+own build. Add `-DWAVESHARE_RP2350B_PLUS_W_BUILD=ON` to the cmake configure
+above, or use the convenience script:
+
+```bash
+PICO_SDK_PATH=/path/to/pico-sdk ./boards/build_waveshare_rp2350b_plus_w.sh
+```
+
+The board header lives in `boards/headers/waveshare_rp2350b_plus_w.h`; it is
+not part of upstream pico-sdk.
+
 ## Companion App
 
 Install dependencies from the lockfile and run the checks:


### PR DESCRIPTION
## Add Waveshare RP2350B-Plus-W as a build target

This adds firmware support for the [Waveshare RP2350B-Plus-W](https://www.waveshare.com/wiki/RP2350B-Plus-W)
— a Pico 2 W form-factor board with USB-C, 16MB flash, an RP2350B, and the
same Raspberry Pi RM2 wireless module as the Pico 2 W.

### Why it needs its own build

Waveshare wired the RM2/CYW43 module to a different set of RP2350 GPIOs than
the official Pico 2 W (WL_REG_ON on GP36 vs GP23; DATA/CS/CLOCK on GP37–39),
so a stock `pico2_w` build cannot drive the radio on this board. The port is
carried by:

- `boards/headers/waveshare_rp2350b_plus_w.h` — board header (not yet in
  upstream pico-sdk), including the boot2_w25q080 boot-stage-2 declaration and
  schematic corrections (VSYS sense on GPIO46, no CYW43-side VBUS pin). This
  is the same header already proven on this hardware in awalol/DS5Dongle.
- A `WAVESHARE_RP2350B_PLUS_W_BUILD` CMake option that selects the board and
  points `PICO_BOARD_HEADER_DIRS` at `boards/headers/`. **The default build
  is untouched** — without the option, `PICO_BOARD` remains `pico2_w`.
- CI builds and uploads `ds5-bridge-companion-waveshare.uf2` alongside the
  existing artifact.

### The toolchain commit is required, not housekeeping

The Ubuntu apt-packaged `gcc-arm-none-eabi` 13.2 (`15:13.2.rel1-2`, what
`ubuntu-latest` installs) produces Waveshare binaries with audible audio
static that ARM's official toolchains do not exhibit; the Pico 2 W build from
the same toolchain is unaffected. This branch therefore switches the firmware
CI to ARM's official 14.2.Rel1 tarball (cached across runs, ~143 MB download
on cache miss only). awalol/DS5Dongle hit the same issue and made the same
switch. Please don't simplify CI back to the apt package — the breakage is
invisible on Pico 2 W and only shows up on Waveshare hardware.

### Optional commits — drop them if you'd rather not ship Waveshare releases

The last two commits add a `DS5-Bridge-Firmware-Waveshare-v{VERSION}.uf2`
asset to the release workflow (plus the manifest entry), and move the release
firmware job to the same ARM toolchain. They're self-contained: if you prefer
to keep Waveshare as a CI-artifact-only target for now, drop them and the
board support stands on its own. If you do keep releases apt-toolchain-based,
note that a future Waveshare release asset would inherit the audio-static
toolchain issue — the two changes belong together.

The remaining commit bumps `actions/checkout` and `actions/cache` to v5 (the
plain Node 24 runtime bumps) to clear the deprecation warning on every run.

### Verification

- Waveshare UF2 verified on real hardware: boots, pairs, works with the 1.6.2
  companion app (protocol/version handshake unchanged — same source, same USB
  identity, only the board pin map differs).
- Default `pico2_w` build confirmed unaffected (configure resolves the same
  board; ELF contains no Waveshare strings and vice versa).
- Full release pipeline exercised on my fork via a test pre-release: both
  firmware assets built and auto-uploaded, `manifest.json` lists both.
