### PR TITLE
ci: run firmware build on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - "**"
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 env:
   PICO_SDK_REF: 2.2.0


### PR DESCRIPTION
## Summary

- run the firmware build workflow on pull requests targeting `main`
- allow the required `Build companion UF2` check to report on PRs
- explicitly limit this workflow's `GITHUB_TOKEN` to read-only repository contents

## Why

`Build companion UF2` is a required branch protection check, but `.github/workflows/build.yml` currently only runs on `push` and `workflow_dispatch`. For fork PRs, that leaves the required check stuck as expected/pending because no PR workflow reports it.

This makes the firmware build workflow run on PRs while keeping the workflow token least-privileged for CI.

## Testing

- [x] `Build firmware` passed on branch push: https://github.com/SundayMoments/DS5_Bridge/actions/runs/28827479099
- [x] `Companion checks` passed on branch push: https://github.com/SundayMoments/DS5_Bridge/actions/runs/28827479075
- [x] `pull_request` trigger passed on this PR