### PR TITLE
fix(waveshare): stabilize RP2350B-Plus-W runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,16 @@ target_compile_definitions(ds5-bridge PRIVATE
         DS5_FIRMWARE_VERSION_MINOR=${DS5_FIRMWARE_VERSION_MINOR}
         DS5_FIRMWARE_VERSION_PATCH=${DS5_FIRMWARE_VERSION_PATCH}
 )
+
+if (WAVESHARE_RP2350B_PLUS_W_BUILD)
+    target_compile_definitions(ds5-bridge PRIVATE
+            # Real hardware stalls when BTstack persists data near the end of
+            # the advertised 16 MiB flash. Keep its two-bank TLV store in the
+            # low-flash region validated by the DS5Dongle Waveshare firmware.
+            DS5_WAVESHARE_STABLE_RUNTIME=1
+            PICO_FLASH_BANK_STORAGE_OFFSET=0x003FD000
+    )
+endif ()
 # Kitsune Input intentionally enumerates as a stock DualSense only. Never turn
 # this on: DualSense Edge USB identity/descriptors are not a supported persona.
 option(ENABLE_DSE "Unsupported: do not enable DualSense Edge USB enumeration" OFF)
@@ -312,4 +322,3 @@ add_custom_command(TARGET ds5-bridge POST_BUILD
 )
 
 pico_add_extra_outputs(ds5-bridge)
-

--- a/boards/headers/waveshare_rp2350b_plus_w.h
+++ b/boards/headers/waveshare_rp2350b_plus_w.h
@@ -24,6 +24,15 @@ pico_board_cmake_set(PICO_DEFAULT_BOOT_STAGE2, boot2_w25q080)
 // --- RP2350 VARIANT ---
 #define PICO_RP2350A 0
 
+// LED1 is CYW43 GPIO0. LED2 is directly connected to RP2350B GPIO23.
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN 23
+#endif
+
+#ifndef PICO_DEFAULT_LED_PIN_INVERTED
+#define PICO_DEFAULT_LED_PIN_INVERTED 0
+#endif
+
 // --- UART ---
 #ifndef PICO_DEFAULT_UART
 #define PICO_DEFAULT_UART 0
@@ -71,7 +80,7 @@ pico_board_cmake_set(PICO_DEFAULT_BOOT_STAGE2, boot2_w25q080)
 #define PICO_FLASH_SPI_CLKDIV 2
 #endif
 
-// pico_cmake_set_default PICO_FLASH_SIZE_BYTES = (4 * 1024 * 1024)
+pico_board_cmake_set_default(PICO_FLASH_SIZE_BYTES, (16 * 1024 * 1024))
 #ifndef PICO_FLASH_SIZE_BYTES
 #define PICO_FLASH_SIZE_BYTES (16 * 1024 * 1024)
 #endif

--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -389,6 +389,18 @@ static uint64_t bt_rssi_pending_epoch = 0;
 static uint64_t bt_rssi_last_activity_us = 0;
 static uint64_t bt_rssi_last_request_us = 0;
 unordered_map<uint8_t, vector<uint8_t> > feature_data;
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+static constexpr uint16_t FEATURE_CACHE_PAYLOAD_MAX = 64;
+
+struct fixed_feature_cache_entry {
+    uint8_t data[FEATURE_CACHE_PAYLOAD_MAX];
+    uint8_t size;
+    bool ready;
+};
+
+static fixed_feature_cache_entry fixed_feature_cache[256]{};
+static critical_section_t fixed_feature_cache_lock;
+#endif
 static feature_prefetch_request feature_prefetch_queue[FEATURE_PREFETCH_MAX_REQUESTS]{};
 static uint8_t feature_prefetch_count = 0;
 static uint8_t feature_prefetch_index = 0;
@@ -417,6 +429,61 @@ static uint8_t saved_lightbar_blue = 0x00;
 static uint8_t saved_lightbar_brightness = 100;
 static bool player_led_enabled = true;
 static bool lightbar_restore_enabled = true;
+
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+static void bt_feature_cache_clear() {
+    critical_section_enter_blocking(&fixed_feature_cache_lock);
+    memset(fixed_feature_cache, 0, sizeof(fixed_feature_cache));
+    critical_section_exit(&fixed_feature_cache_lock);
+}
+
+static void bt_feature_cache_store(
+    uint8_t report_id,
+    uint8_t const *payload,
+    uint16_t payload_size
+) {
+    if (payload == nullptr) {
+        return;
+    }
+    const uint8_t copy_size = static_cast<uint8_t>(
+        std::min<uint16_t>(payload_size, FEATURE_CACHE_PAYLOAD_MAX)
+    );
+    critical_section_enter_blocking(&fixed_feature_cache_lock);
+    fixed_feature_cache_entry &entry = fixed_feature_cache[report_id];
+    memcpy(entry.data, payload, copy_size);
+    if (copy_size < sizeof(entry.data)) {
+        memset(entry.data + copy_size, 0, sizeof(entry.data) - copy_size);
+    }
+    entry.size = copy_size;
+    entry.ready = true;
+    critical_section_exit(&fixed_feature_cache_lock);
+}
+
+void bt_feature_cache_init_before_tusb() {
+    critical_section_init(&fixed_feature_cache_lock);
+    bt_feature_cache_clear();
+}
+
+uint16_t bt_copy_cached_feature(
+    uint8_t report_id,
+    uint8_t *buffer,
+    uint16_t requested_length
+) {
+    if (buffer == nullptr || requested_length == 0) {
+        return 0;
+    }
+
+    uint16_t copy_size = 0;
+    critical_section_enter_blocking(&fixed_feature_cache_lock);
+    fixed_feature_cache_entry const &entry = fixed_feature_cache[report_id];
+    if (entry.ready) {
+        copy_size = std::min<uint16_t>(requested_length, entry.size);
+        memcpy(buffer, entry.data, copy_size);
+    }
+    critical_section_exit(&fixed_feature_cache_lock);
+    return copy_size;
+}
+#endif
 static bool lightbar_restore_pending = false;
 static uint32_t lightbar_restore_at_us = 0;
 static uint8_t state_report_seq = 0;
@@ -2303,6 +2370,9 @@ bool bt_forget_pairings() {
     stored_link_key_present = false;
     current_link_key_persisted = false;
     feature_data.clear();
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+    bt_feature_cache_clear();
+#endif
     clear_feature_prefetch_queue();
 
     return bt_request_scan();
@@ -2347,6 +2417,9 @@ bool bt_forget_pairing(uint8_t address[6]) {
     if (targets_current_session) {
         current_link_key_persisted = false;
         feature_data.clear();
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+        bt_feature_cache_clear();
+#endif
         clear_feature_prefetch_queue();
         if (acl_handle != HCI_CON_HANDLE_INVALID || hid_interrupt_ready) {
             (void)bt_disconnect();
@@ -3403,6 +3476,9 @@ static void hci_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *p
             hid_control_opened_at_us = 0;
             audio_handle_controller_disconnect();
             feature_data.clear();
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+            bt_feature_cache_clear();
+#endif
             clear_feature_prefetch_queue();
             controller_type = ControllerTypeUnknown;
             controller_type_check_pending = false;
@@ -3795,6 +3871,9 @@ static void l2cap_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t 
                 uint8_t report_id = packet[1];
                 if (feature_data.size() < 32 || feature_data.contains(report_id)) {
                     feature_data[report_id].assign(packet + 1, packet + size);
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+                    bt_feature_cache_store(report_id, packet + 2, size - 2);
+#endif
                     DS5_LOG("[L2CAP] Stored Feature Report 0x%02X, len=%u\n", report_id, size - 1);
                 }
             }
@@ -5152,6 +5231,9 @@ void set_feature_data(uint8_t reportId, uint8_t const* data,uint16_t len) {
 
 void init_feature() {
     controller_type = ControllerTypeUnknown;
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+    bt_feature_cache_clear();
+#endif
     clear_feature_prefetch_queue();
     controller_type_check_pending = true;
     schedule_feature_prefetch(0x70, 64);

--- a/src/bt.h
+++ b/src/bt.h
@@ -129,6 +129,10 @@ void bt_inquiry_loop();
 void bt_connection_recovery_loop();
 void bt_feature_prefetch_loop();
 void bt_output_retry_loop();
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+void bt_feature_cache_init_before_tusb();
+uint16_t bt_copy_cached_feature(uint8_t report_id, uint8_t *buffer, uint16_t requested_length);
+#endif
 std::vector<uint8_t> get_feature_data(uint8_t reportId,uint16_t len);
 void init_feature();
 void set_feature_data(uint8_t reportId, uint8_t const* data,uint16_t len);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,6 +37,7 @@
 
 // Pico SDK support for waiting on conditions.
 #include "pico/critical_section.h"
+#include "pico/util/queue.h"
 
 int reportSeqCounter = 0;
 static constexpr uint32_t HOST_LIGHTBAR_RESTORE_DELAY_MS = 3000;
@@ -281,6 +282,61 @@ static bool dualsense_feature_report_may_use_bt_passthrough(uint8_t report_id) {
     return bt_controller_type() != ControllerTypeDualSenseEdge;
 }
 
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+struct UsbHidSetReportWork {
+    uint8_t interface_number;
+    uint8_t report_id;
+    hid_report_type_t report_type;
+    uint8_t size;
+    uint8_t data[64];
+};
+
+struct UsbHidGetFeatureWork {
+    uint8_t report_id;
+    uint16_t requested_length;
+};
+
+static queue_t usb_hid_set_report_queue;
+static queue_t usb_hid_get_feature_queue;
+
+static void usb_hid_work_init_before_tusb() {
+    queue_init(&usb_hid_set_report_queue, sizeof(UsbHidSetReportWork), 8);
+    queue_init(&usb_hid_get_feature_queue, sizeof(UsbHidGetFeatureWork), 8);
+}
+
+static void queue_usb_hid_set_report(
+    uint8_t interface_number,
+    uint8_t report_id,
+    hid_report_type_t report_type,
+    uint8_t const *data,
+    uint16_t size
+) {
+    UsbHidSetReportWork work{};
+    work.interface_number = interface_number;
+    work.report_id = report_id;
+    work.report_type = report_type;
+    work.size = static_cast<uint8_t>(std::min<uint16_t>(size, sizeof(work.data)));
+    if (work.size > 0 && data != nullptr) {
+        memcpy(work.data, data, work.size);
+    }
+
+    if (!queue_try_add(&usb_hid_set_report_queue, &work)) {
+        UsbHidSetReportWork stale{};
+        (void)queue_try_remove(&usb_hid_set_report_queue, &stale);
+        (void)queue_try_add(&usb_hid_set_report_queue, &work);
+    }
+}
+
+static void queue_usb_hid_get_feature(uint8_t report_id, uint16_t requested_length) {
+    UsbHidGetFeatureWork work{report_id, requested_length};
+    if (!queue_try_add(&usb_hid_get_feature_queue, &work)) {
+        UsbHidGetFeatureWork stale{};
+        (void)queue_try_remove(&usb_hid_get_feature_queue, &stale);
+        (void)queue_try_add(&usb_hid_get_feature_queue, &work);
+    }
+}
+#endif
+
 void host_input_prepare_persona_switch() {
     const HostPersonaMode current_persona = host_persona_active();
     const BridgeControllerState neutral_state = neutral_controller_state();
@@ -313,7 +369,13 @@ void reset_controller_input_report_cache() {
     critical_section_enter_blocking(&report_cs);
     memcpy(interrupt_in_data, kNeutralDualSenseUsbInputReport, sizeof(interrupt_in_data));
     interrupt_in_state = default_state;
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+    // The Waveshare build retains its enumerated USB persona across a
+    // controller reconnect, so publish one neutral report immediately.
+    report_dirty = true;
+#else
     report_dirty = false;
+#endif
     critical_section_exit(&report_cs);
 }
 
@@ -444,6 +506,17 @@ uint16_t tud_hid_get_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t
         return 0;
     }
 
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+    if (dualsense_feature_report_may_use_bt_passthrough(report_id)) {
+        const uint16_t cached_length = bt_copy_cached_feature(report_id, buffer, reqlen);
+        if (cached_length > 0) {
+            return cached_length;
+        }
+        // A USB control callback must not allocate or submit L2CAP work. Ask
+        // the main loop to refresh the cache and let the host retry.
+        queue_usb_hid_get_feature(report_id, reqlen);
+    }
+#else
     std::vector<uint8_t> feature_data;
     if (dualsense_feature_report_may_use_bt_passthrough(report_id)) {
         feature_data = get_feature_data(report_id, reqlen);
@@ -457,14 +530,13 @@ uint16_t tud_hid_get_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t
 
         return copy_len;
     }
+#endif
 
     return dualsense_persona_get_feature_report(report_id, buffer, reqlen);
 }
 
-// Invoked when received SET_REPORT control request or
-// received data on OUT endpoint ( Report ID = 0, Type = 0 )
-void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t report_type, uint8_t const *buffer,
-                           uint16_t bufsize) {
+static void process_hid_set_report(uint8_t itf, uint8_t report_id, hid_report_type_t report_type,
+                                   uint8_t const *buffer, uint16_t bufsize) {
     (void) itf;
     (void) report_id;
     (void) report_type;
@@ -553,6 +625,41 @@ void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t rep
     }
 }
 
+// Invoked when received SET_REPORT control request or data on the OUT endpoint.
+void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t report_type,
+                           uint8_t const *buffer, uint16_t bufsize) {
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+    // TinyUSB can invoke this while EP0/OUT state is timing-sensitive. Copy
+    // bounded input only; heap, companion and Bluetooth work runs later.
+    if (buffer == nullptr && bufsize > 0) {
+        return;
+    }
+    queue_usb_hid_set_report(itf, report_id, report_type, buffer, bufsize);
+#else
+    process_hid_set_report(itf, report_id, report_type, buffer, bufsize);
+#endif
+}
+
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+static void usb_hid_work_task() {
+    UsbHidSetReportWork set_work{};
+    while (queue_try_remove(&usb_hid_set_report_queue, &set_work)) {
+        process_hid_set_report(
+            set_work.interface_number,
+            set_work.report_id,
+            set_work.report_type,
+            set_work.data,
+            set_work.size
+        );
+    }
+
+    UsbHidGetFeatureWork get_work{};
+    while (queue_try_remove(&usb_hid_get_feature_queue, &get_work)) {
+        (void)get_feature_data(get_work.report_id, get_work.requested_length);
+    }
+}
+#endif
+
 int main() {
 #if SYS_CLOCK_KHZ != 150000
     vreg_set_voltage(VREG_VOLTAGE_1_20);
@@ -563,6 +670,11 @@ int main() {
     board_init();
     watchdog_telemetry_boot_capture();
     firmware_log_init();
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+    // Windows may issue HID control requests as soon as TinyUSB starts.
+    bt_feature_cache_init_before_tusb();
+    usb_hid_work_init_before_tusb();
+#endif
     usb_device_stack_init_disconnected();
 #if DS5_DEBUG_LOGS_ENABLED
     // TinyUSB's board_init() configures its UART at 115200. Reinitialize stdio
@@ -624,6 +736,9 @@ int main() {
         RUN_MAIN_PHASE(WatchdogMainLoopPhase::TinyUsb, {
             tud_task();
         });
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+        usb_hid_work_task();
+#endif
         RUN_MAIN_PHASE(
             WatchdogMainLoopPhase::FirmwareLogFlush,
             {

--- a/src/usb.cpp
+++ b/src/usb.cpp
@@ -226,6 +226,15 @@ void usb_handle_controller_transport_disconnect(bool expected_disconnect) {
     usb_reconnect_requested = false;
     usb_reconnect_connect_pending = false;
     usb_controller_transport_ready = false;
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+    if (usb_controller_transport_attached || usb_mounted) {
+        // Retain the enumerated persona while Bluetooth reconnects. Repeated
+        // firmware-driven detach/attach cycles are unreliable on this board.
+        usb_controller_transport_disconnect_not_before_us = 0;
+        usb_controller_transport_transition_pending = false;
+        return;
+    }
+#endif
     usb_controller_transport_disconnect_not_before_us = expected_disconnect
         ? time_us_32() + USB_EXPECTED_DISCONNECT_GRACE_US
         : 0;


### PR DESCRIPTION
## Summary

- Move BTstack TLV persistence to a low-flash region validated on physical Waveshare RP2350B-Plus-W hardware.
- Correct the board's 16 MiB flash metadata and expose the directly connected LED on GPIO23.
- Serve controller feature reports from fixed storage instead of allocating from TinyUSB control callbacks.
- Defer HID GET/SET processing to the main loop so USB callbacks do not initiate heap, companion, or Bluetooth work.
- Retain the enumerated USB controller persona while Bluetooth reconnects.

## Root cause

Testing on a physical Waveshare RP2350B-Plus-W showed that BTstack persistence near the end of the advertised 16 MiB flash could stall startup or pairing initialization.

USB control callbacks could also allocate dynamic storage and schedule Bluetooth work while TinyUSB endpoint state was timing-sensitive. This resulted in unstable enumeration or a controller that accepted normal input while advanced features such as rumble, adaptive triggers, feature reports, and audio did not work reliably.

## Hardware validation

Validated on a physical Waveshare RP2350B-Plus-W with:

- Bluetooth pairing and reconnect
- Controller input
- Rumble and lightbar output
- Adaptive triggers
- Feature reports
- Native audio haptics
- Controller speaker audio
- Controller microphone
- Windows speaker and microphone endpoints
- Companion functionality
- USB and controller reconnects

## Build validation

Successfully built the companion firmware with:

- Pico SDK 2.2.0
- TinyUSB 0.20.0
- Arm GNU Toolchain 14.2.Rel1
- Waveshare RP2350B-Plus-W target
- Standard Pico 2 W target

The Waveshare-specific runtime behavior is compile-time gated and does not affect the standard Pico 2 W build.

## Hardware evidence

<img width="1280" height="960" alt="Tested on a physical Waveshare RP2350B-Plus-W" src="https://github.com/user-attachments/assets/3438dba4-10db-4d92-a580-791ad8606dde" />

<img width="1120" height="630" alt="DS5 Bridge" src="https://github.com/user-attachments/assets/9ff1f2e0-454f-4316-8066-ae70fadaa6f6" />

