### PR TITLE
fix: correct persona microphone handling

### DIFF
--- a/companion/src/renderer/App.tsx
+++ b/companion/src/renderer/App.tsx
@@ -91,6 +91,11 @@ import triangleGlyphUrl from '../../../assets/glyphs/ps5-buttons-outline-white/s
 import kitsuneInputLogoUrl from './assets/kitsune-input-logo.svg';
 import testSpeakerToneUrl from './assets/test-speaker-tone-silence-tail.mp3';
 import {
+  bridgeAudioInputLabelScore,
+  bridgeAudioOutputLabelScore,
+  isBridgeAudioDeviceLabel
+} from './audio-endpoint-matching';
+import {
   DEFAULT_UI_THEME_PRESET,
   UI_THEME_KOFI_BADGES,
   UI_THEME_OPTIONS,
@@ -365,10 +370,8 @@ const PERCENT_SLIDER_TICKS = Array.from({ length: 11 }, (_, index) => index * 10
 const TRIGGER_LAB_SLIDER_STEP = 5;
 const TRIGGER_LAB_SLIDER_TICKS = Array.from({ length: 21 }, (_, index) => index * TRIGGER_LAB_SLIDER_STEP);
 const STANDARD_HAPTICS_SLIDER_TICKS = Array.from({ length: 11 }, (_, index) => index * 20);
-const BRIDGE_AUDIO_OUTPUT_RE = /ds5|dualsense|dual sense|wireless controller|bridge/i;
-const BRIDGE_AUDIO_INPUT_RE = /ds5|dualsense|dual sense|wireless controller|bridge/i;
-const BRIDGE_AUDIO_ENDPOINT_UNAVAILABLE = 'DualSense audio endpoint unavailable';
-const BRIDGE_MIC_ENDPOINT_UNAVAILABLE = 'DualSense microphone unavailable';
+const BRIDGE_AUDIO_ENDPOINT_UNAVAILABLE = 'Controller audio endpoint unavailable';
+const BRIDGE_MIC_ENDPOINT_UNAVAILABLE = 'Controller microphone unavailable';
 const MUTE_KEY_OPTIONS: Array<[string, number]> = [
   ['F1', 0x3A], ['F2', 0x3B], ['F3', 0x3C], ['F4', 0x3D], ['F5', 0x3E], ['F6', 0x3F],
   ['F7', 0x40], ['F8', 0x41], ['F9', 0x42], ['F10', 0x43], ['F11', 0x44], ['F12', 0x45],
@@ -1997,38 +2000,12 @@ function hexByte(value: number): string {
   return value.toString(16).padStart(2, '0').toUpperCase();
 }
 
-function normalizeAudioDeviceLabel(label: string): string {
-  return label
-    .toLowerCase()
-    .replace(/^\s*\d+\s*-\s*/, '')
-    .replace(/\s+/g, ' ')
-    .trim();
-}
-
-function isBridgeAudioLabel(label: string): boolean {
-  return BRIDGE_AUDIO_OUTPUT_RE.test(normalizeAudioDeviceLabel(label));
-}
-
 function bridgeAudioOutputScore(device: MediaDeviceInfo): number {
-  const label = normalizeAudioDeviceLabel(device.label);
-  let score = 1;
-  if (label.includes('dualsense') || label.includes('dual sense')) score += 4;
-  if (label.includes('wireless controller')) score += 3;
-  if (label.includes('speaker') || label.includes('headphone') || label.includes('headset')) score += 2;
-  if (label.includes('microphone') || label.includes('mic')) score -= 4;
-  if (label.includes('ds5') || label.includes('bridge')) score += 1;
-  return score;
+  return bridgeAudioOutputLabelScore(device.label);
 }
 
 function bridgeAudioInputScore(device: MediaDeviceInfo): number {
-  const label = normalizeAudioDeviceLabel(device.label);
-  let score = 1;
-  if (label.includes('dualsense') || label.includes('dual sense')) score += 4;
-  if (label.includes('wireless controller')) score += 3;
-  if (label.includes('microphone') || label.includes('mic')) score += 2;
-  if (label.includes('speaker') || label.includes('headphone')) score -= 4;
-  if (label.includes('ds5') || label.includes('bridge')) score += 1;
-  return score;
+  return bridgeAudioInputLabelScore(device.label);
 }
 
 async function findBridgeAudioOutputIdOnce(): Promise<string | null> {
@@ -2040,7 +2017,7 @@ async function findBridgeAudioOutputIdOnce(): Promise<string | null> {
     const devices = await navigator.mediaDevices.enumerateDevices();
     const outputs = devices.filter((device) => (
       device.kind === 'audiooutput'
-      && isBridgeAudioLabel(device.label)
+      && isBridgeAudioDeviceLabel(device.label)
       && device.deviceId
       && device.deviceId !== 'default'
       && device.deviceId !== 'communications'
@@ -2062,7 +2039,7 @@ async function findBridgeAudioInputIdOnce(): Promise<string | null> {
     const devices = await navigator.mediaDevices.enumerateDevices();
     const inputs = devices.filter((device) => (
       device.kind === 'audioinput'
-      && BRIDGE_AUDIO_INPUT_RE.test(normalizeAudioDeviceLabel(device.label))
+      && isBridgeAudioDeviceLabel(device.label)
       && device.deviceId
       && device.deviceId !== 'default'
       && device.deviceId !== 'communications'

--- a/companion/src/renderer/audio-endpoint-matching.test.ts
+++ b/companion/src/renderer/audio-endpoint-matching.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  bridgeAudioInputLabelScore,
+  bridgeAudioOutputLabelScore,
+  isBridgeAudioDeviceLabel,
+  normalizeAudioDeviceLabel
+} from './audio-endpoint-matching';
+
+describe('renderer audio endpoint matching', () => {
+  it.each([
+    'Speakers (DualSense Wireless Controller)',
+    'Microphone (DualSense Edge Wireless Controller)',
+    'Headset Earphone (Wireless Controller)',
+    'Headset Microphone (Xbox 360 Controller for Windows)',
+    'Speakers (Xbox 360 Controller for Windows)',
+    'DS5 Bridge Audio'
+  ])('recognizes bridge persona endpoint %s', (label) => {
+    expect(isBridgeAudioDeviceLabel(label)).toBe(true);
+  });
+
+  it.each([
+    'Microphone (Yeti Classic)',
+    'Speakers (Realtek(R) Audio)',
+    'Xbox Wireless Headset'
+  ])('rejects unrelated endpoint %s', (label) => {
+    expect(isBridgeAudioDeviceLabel(label)).toBe(false);
+  });
+
+  it('normalizes Windows endpoint prefixes and whitespace', () => {
+    expect(normalizeAudioDeviceLabel('  2 -  Headset   Microphone (Xbox 360 Controller for Windows) '))
+      .toBe('headset microphone (xbox 360 controller for windows)');
+  });
+
+  it('prefers capture labels for input and playback labels for output', () => {
+    const input = 'Headset Microphone (Xbox 360 Controller for Windows)';
+    const output = 'Speakers (Xbox 360 Controller for Windows)';
+
+    expect(bridgeAudioInputLabelScore(input)).toBeGreaterThan(bridgeAudioInputLabelScore(output));
+    expect(bridgeAudioOutputLabelScore(output)).toBeGreaterThan(bridgeAudioOutputLabelScore(input));
+  });
+});

--- a/companion/src/renderer/audio-endpoint-matching.ts
+++ b/companion/src/renderer/audio-endpoint-matching.ts
@@ -1,0 +1,44 @@
+const BRIDGE_AUDIO_LABEL_PATTERNS = [
+  /\bds5\b/i,
+  /\bdual\s*sense\b/i,
+  /\bwireless controller\b/i,
+  /\bxbox 360 controller for windows\b/i,
+  /\bds5 bridge\b/i
+];
+
+export function normalizeAudioDeviceLabel(label: string): string {
+  return label
+    .toLowerCase()
+    .replace(/^\s*\d+\s*-\s*/, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function isBridgeAudioDeviceLabel(label: string): boolean {
+  const normalizedLabel = normalizeAudioDeviceLabel(label);
+  return BRIDGE_AUDIO_LABEL_PATTERNS.some((pattern) => pattern.test(normalizedLabel));
+}
+
+export function bridgeAudioOutputLabelScore(rawLabel: string): number {
+  const label = normalizeAudioDeviceLabel(rawLabel);
+  let score = 1;
+  if (label.includes('dualsense') || label.includes('dual sense')) score += 4;
+  if (label.includes('wireless controller')) score += 3;
+  if (label.includes('xbox 360 controller for windows')) score += 4;
+  if (label.includes('speaker') || label.includes('headphone') || label.includes('headset')) score += 2;
+  if (label.includes('microphone') || label.includes('mic')) score -= 4;
+  if (label.includes('ds5') || label.includes('bridge')) score += 1;
+  return score;
+}
+
+export function bridgeAudioInputLabelScore(rawLabel: string): number {
+  const label = normalizeAudioDeviceLabel(rawLabel);
+  let score = 1;
+  if (label.includes('dualsense') || label.includes('dual sense')) score += 4;
+  if (label.includes('wireless controller')) score += 3;
+  if (label.includes('xbox 360 controller for windows')) score += 4;
+  if (label.includes('microphone') || label.includes('mic')) score += 2;
+  if (label.includes('speaker') || label.includes('headphone')) score -= 4;
+  if (label.includes('ds5') || label.includes('bridge')) score += 1;
+  return score;
+}

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -10,6 +10,7 @@
 #include "controller_output_state.h"
 #include "dualsense_output.h"
 #include "haptics_test_signal.h"
+#include "persona/host_persona.h"
 #include "usb_audio_render_gain.h"
 #ifdef ENABLE_COMPANION
 #include "companion.h"
@@ -68,17 +69,15 @@
 #define HOST_MIC_OPUS_SIZE 71
 #define HOST_MIC_OPUS_FRAMES 480
 #define HOST_MIC_INPUT_CHANNELS 1
-#define HOST_MIC_USB_CHANNELS CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX
+#define HOST_MIC_USB_CHANNELS_MAX CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX
 #define HOST_MIC_QUEUE_DEPTH 8
-#define HOST_MIC_USB_PACKET_BYTES (48 * HOST_MIC_USB_CHANNELS * sizeof(int16_t))
-#define HOST_MIC_USB_PREFILL_BYTES (64 * HOST_MIC_USB_PACKET_BYTES)
+#define HOST_MIC_USB_PACKET_BYTES_MAX (48 * HOST_MIC_USB_CHANNELS_MAX * sizeof(int16_t))
 #define HOST_MIC_USB_FILL_MAX_CHUNKS 6
 #define HOST_MIC_USB_FILL_MAX_CHUNKS_WITH_RAW_PCM 4
 #define HOST_MIC_CORE1_BURST_LIMIT 2
 #define HOST_MIC_PLAYOUT_START_DEPTH 12
 #define HOST_MIC_OPUS_FRAME_INTERVAL_US 10000
 #define HOST_MIC_PLC_TARGET_DEPTH 1
-#define HOST_MIC_PLC_RESERVOIR_BYTES (40 * HOST_MIC_USB_PACKET_BYTES)
 #define HOST_MIC_PLC_EMPTY_GRACE_US 30000
 #define BRIDGE_AUDIO_STREAM_REPORT_ID 0x07
 #define BRIDGE_AUDIO_FAST_FRAME_FRAGMENT_TYPE 0x08
@@ -118,10 +117,26 @@ struct mic_packet_element {
 };
 
 struct mic_decode_element {
-    int16_t data[HOST_MIC_OPUS_FRAMES * HOST_MIC_USB_CHANNELS];
+    int16_t data[HOST_MIC_OPUS_FRAMES * HOST_MIC_USB_CHANNELS_MAX];
     uint16_t len;
     uint32_t generation;
 };
+
+static uint8_t host_mic_usb_channel_count() {
+    return host_persona_active() == HostPersonaModeDualSenseEdge ? 2 : 1;
+}
+
+static uint16_t host_mic_usb_packet_bytes() {
+    return static_cast<uint16_t>(48 * host_mic_usb_channel_count() * sizeof(int16_t));
+}
+
+static uint16_t host_mic_usb_prefill_bytes() {
+    return static_cast<uint16_t>(64 * host_mic_usb_packet_bytes());
+}
+
+static uint32_t host_mic_plc_reservoir_bytes() {
+    return static_cast<uint32_t>(40 * host_mic_usb_packet_bytes());
+}
 
 struct speaker_opus_element {
     uint8_t data[SPEAKER_OPUS_SIZE];
@@ -1959,25 +1974,26 @@ static void process_idle_speaker_silence_preroll(uint32_t now) {
 }
 
 static bool write_mic_usb_concealment_chunk(tu_fifo_t *ep_in_fifo) {
+    const uint16_t packet_bytes = host_mic_usb_packet_bytes();
     if (ep_in_fifo != nullptr) {
-        if (tu_fifo_count(ep_in_fifo) >= HOST_MIC_USB_PACKET_BYTES) {
+        if (tu_fifo_count(ep_in_fifo) >= packet_bytes) {
             return false;
         }
-        if (tu_fifo_remaining(ep_in_fifo) < HOST_MIC_USB_PACKET_BYTES) {
+        if (tu_fifo_remaining(ep_in_fifo) < packet_bytes) {
             return false;
         }
     }
 
-    alignas(2) uint8_t chunk[HOST_MIC_USB_PACKET_BYTES]{};
-    const uint16_t written = tud_audio_n_write(0, chunk, HOST_MIC_USB_PACKET_BYTES);
+    alignas(2) uint8_t chunk[HOST_MIC_USB_PACKET_BYTES_MAX]{};
+    const uint16_t written = tud_audio_n_write(0, chunk, packet_bytes);
     mic_last_written_bytes = written;
-    if (written != HOST_MIC_USB_PACKET_BYTES) {
+    if (written != packet_bytes) {
         mic_usb_write_short++;
         audio_debug_log(
             AudioDebugMicPacket,
             12,
             clamp_debug_u8(written),
-            HOST_MIC_USB_PACKET_BYTES,
+            clamp_debug_u8(packet_bytes),
             clamp_debug_u8(mic_usb_write_short),
             0
         );
@@ -2005,12 +2021,13 @@ static void configure_mic_usb_fifo_threshold(tu_fifo_t *ep_in_fifo) {
     }
 
     const uint16_t depth = tu_fifo_depth(ep_in_fifo);
-    if (depth <= HOST_MIC_USB_PACKET_BYTES) {
+    const uint16_t packet_bytes = host_mic_usb_packet_bytes();
+    if (depth <= packet_bytes) {
         return;
     }
 
-    const uint16_t max_threshold = static_cast<uint16_t>(depth - HOST_MIC_USB_PACKET_BYTES);
-    const uint16_t threshold = std::min<uint16_t>(HOST_MIC_USB_PREFILL_BYTES, max_threshold);
+    const uint16_t max_threshold = static_cast<uint16_t>(depth - packet_bytes);
+    const uint16_t threshold = std::min<uint16_t>(host_mic_usb_prefill_bytes(), max_threshold);
     tud_audio_n_set_ep_in_fifo_threshold(0, threshold);
     mic_usb_fifo_threshold_configured = true;
 }
@@ -2045,7 +2062,7 @@ static __attribute__((noinline, noclone)) bool __not_in_flash_func(write_mic_usb
 
     tu_fifo_t *ep_in_fifo = tud_audio_n_get_ep_in_ff(0);
     const uint16_t remaining = static_cast<uint16_t>(mic_usb_pending_len - mic_usb_pending_offset);
-    uint16_t target_len = std::min<uint16_t>(remaining, HOST_MIC_USB_PACKET_BYTES);
+    uint16_t target_len = std::min<uint16_t>(remaining, host_mic_usb_packet_bytes());
     if (ep_in_fifo != nullptr) {
         target_len = std::min<uint16_t>(target_len, tu_fifo_remaining(ep_in_fifo));
         target_len = static_cast<uint16_t>(target_len & ~1u);
@@ -2060,7 +2077,7 @@ static __attribute__((noinline, noclone)) bool __not_in_flash_func(write_mic_usb
     }
 
     const uint8_t *data = reinterpret_cast<uint8_t const *>(mic_usb_pending.data) + mic_usb_pending_offset;
-    alignas(2) uint8_t scaled_data[HOST_MIC_USB_PACKET_BYTES]{};
+    alignas(2) uint8_t scaled_data[HOST_MIC_USB_PACKET_BYTES_MAX]{};
     uint8_t const *write_data = data;
     const uint8_t output_percent = mic_output_muted ? 0 : mic_output_volume_percent;
     if (output_percent < 100) {
@@ -2316,6 +2333,7 @@ static bool queue_mic_decoded_samples(
 
     static mic_decode_element decoded{};
     const int frames = std::min(decoded_samples, HOST_MIC_OPUS_FRAMES);
+    const uint8_t usb_channels = host_mic_usb_channel_count();
     uint32_t peak = 0;
     for (int frame = 0; frame < frames; frame++) {
         const int32_t sample = decoded_mono[frame];
@@ -2323,11 +2341,11 @@ static bool queue_mic_decoded_samples(
         if (magnitude > peak) {
             peak = magnitude;
         }
-        for (int channel = 0; channel < HOST_MIC_USB_CHANNELS; channel++) {
-            decoded.data[frame * HOST_MIC_USB_CHANNELS + channel] = decoded_mono[frame];
+        for (int channel = 0; channel < usb_channels; channel++) {
+            decoded.data[frame * usb_channels + channel] = decoded_mono[frame];
         }
     }
-    decoded.len = static_cast<uint16_t>(frames * HOST_MIC_USB_CHANNELS * sizeof(int16_t));
+    decoded.len = static_cast<uint16_t>(frames * usb_channels * sizeof(int16_t));
     decoded.generation = generation;
     if (count_packet_decode) {
         mic_decode_success++;
@@ -2402,9 +2420,9 @@ static bool __not_in_flash_func(core1_process_mic)() {
 static bool mic_playout_reservoir_needs_plc(uint8_t decoded_level) {
     const uint32_t decoded_bytes = static_cast<uint32_t>(decoded_level)
         * HOST_MIC_OPUS_FRAMES
-        * HOST_MIC_USB_CHANNELS
+        * host_mic_usb_channel_count()
         * sizeof(int16_t);
-    return mic_usb_buffered_bytes + decoded_bytes < HOST_MIC_PLC_RESERVOIR_BYTES;
+    return mic_usb_buffered_bytes + decoded_bytes < host_mic_plc_reservoir_bytes();
 }
 
 static bool __not_in_flash_func(core1_process_mic_plc)() {

--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -72,7 +72,6 @@
 #define DS_OUTPUT_POWER_SAVE_CONTROL_MIC_MUTE 0x10
 #define DS_OUTPUT_HEADPHONE_VOLUME_MAX 0x7f
 #define DS_OUTPUT_SPEAKER_VOLUME_MAX 0x64
-#define DS_OUTPUT_MIC_VOLUME_MAX 0x40
 #define DS_OUTPUT_AUDIO_FLAGS2_SPEAKER_PREAMP_GAIN 0x04
 #define DS_OUTPUT_LIGHTBAR_SETUP_LIGHT_OUT 0x02
 #define DS_TRIGGER_EFFECT_SIZE 11
@@ -2156,7 +2155,7 @@ void bt_set_microphone_state(uint8_t volume_percent, bool muted, bool control_mu
     }
     report[3 + OUTPUT_PAYLOAD_MIC_VOLUME_OFFSET] = muted
         ? 0
-        : static_cast<uint8_t>((companion_mic_volume_percent * DS_OUTPUT_MIC_VOLUME_MAX + 50) / 100);
+        : ds5::output::mic_volume_from_percent(companion_mic_volume_percent);
     report[3 + OUTPUT_PAYLOAD_POWER_SAVE_CONTROL_OFFSET] = muted ? DS_OUTPUT_POWER_SAVE_CONTROL_MIC_MUTE : 0;
     bt_write(report, sizeof(report));
 }

--- a/src/dualsense_output.h
+++ b/src/dualsense_output.h
@@ -43,7 +43,7 @@ constexpr uint8_t kPowerSaveControlMicMute = 0x10;
 
 constexpr uint8_t kHeadphoneVolumeMax = 0x7f;
 constexpr uint8_t kSpeakerVolumeMax = 0x64;
-constexpr uint8_t kMicVolumeMax = 0x40;
+constexpr uint8_t kMicVolumeMax = 0x30;
 // DualSense 0x39 declares seven audio sections. Bit 7 is reserved and must
 // remain clear; bit 0 controls controller-microphone transport.
 constexpr uint8_t kAudioSectionEnableMask = 0x7f;
@@ -90,6 +90,11 @@ constexpr uint8_t kLightbarSetupControlMask = 0x03;
 constexpr uint8_t kHostLedControlMask = 0x04 | 0x08 | 0x10;
 constexpr uint8_t kHostLightbarSetupMask = 0x01 | 0x02;
 constexpr uint8_t kEdgeProfileSwitchingBlocked = 0x80;
+
+constexpr uint8_t mic_volume_from_percent(uint8_t volume_percent) {
+    const uint8_t clamped = volume_percent > 100 ? 100 : volume_percent;
+    return static_cast<uint8_t>((static_cast<uint16_t>(clamped) * kMicVolumeMax + 50) / 100);
+}
 
 inline bool payload_has_len(uint16_t len, uint8_t offset) {
     return len > offset;

--- a/src/tusb_config.h
+++ b/src/tusb_config.h
@@ -132,8 +132,9 @@
 #define CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_RX      2
 #define CFG_TUD_AUDIO_FUNC_1_RESOLUTION_RX              16
 
-// Microphone (IN/TX) path: 1-channel, 16-bit.
-#define CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX              1
+// The largest runtime controller-microphone contract is DualSense Edge stereo.
+// Other personas expose mono and use only one channel of this allocation.
+#define CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX              2
 #define CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_TX      2
 #define CFG_TUD_AUDIO_FUNC_1_RESOLUTION_TX              16
 

--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -58,8 +58,10 @@ extern void host_bridge_set_report(uint8_t const *report, uint16_t len);
 #define DUALSENSE_EDGE_HID_REPORT_DESC_FNV1A32 0x48E90EC1u
 #define DUALSENSE_EDGE_VENDOR_ID 0x054C
 #define DUALSENSE_EDGE_PRODUCT_ID 0x0DF2
-#define DUALSENSE_EDGE_USB_BCD_DEVICE 0x0100
+#define DUALSENSE_EDGE_USB_BCD_DEVICE 0x0101
 #define DUALSENSE_EDGE_STRING_PRODUCT "DualSense Edge Wireless Controller"
+#define DUALSENSE_EDGE_AUDIO_EXTRA_LEN 0x0001
+#define CONTROLLER_MIC_MONO_EP_SIZE 0x0060
 #define XUSB_MS_OS_VENDOR_REQUEST 0x21
 #define XUSB360_CONFIG_EXTRA_LEN 0x0007
 #define XUSB360_INTERFACE_DESC_LEN 0x0028
@@ -75,12 +77,12 @@ extern void host_bridge_set_report(uint8_t const *report, uint16_t len);
 #define XUSB360_EP_OUT_INTERVAL 0x08
 #define XUSB360_VENDOR_ID 0x1209
 #define XUSB360_PRODUCT_ID 0xDB05
-#define XUSB360_USB_BCD_DEVICE 0x0156
+#define XUSB360_USB_BCD_DEVICE 0x0157
 #define XUSB360_STRING_MANUFACTURER "Microsoft Corporation"
 #define XUSB360_STRING_PRODUCT "Xbox 360 Controller for Windows"
 #define DS4_VENDOR_ID 0x054C
 #define DS4_PRODUCT_ID 0x09CC
-#define DS4_USB_BCD_DEVICE 0x0103
+#define DS4_USB_BCD_DEVICE 0x0104
 #define DS4_HID_REPORT_DESC_LEN 0x01FB
 #define DS4_HID_REPORT_DESC_FNV1A32 0x9316A41Du
 #define DS4_HID_EP_INTERVAL 0x04
@@ -135,9 +137,9 @@ static tusb_desc_device_t const desc_device =
     // cleanup with tools/windows/clean-ds5bridge-devices.ps1.
     .idVendor = 0x054C,
     .idProduct = 0x0CE6,
-    // Remote wake changes the configuration descriptor. Bump the revision so
-    // Windows does not reuse its cached non-wake descriptor.
-    .bcdDevice = 0x0154,
+    // Persona-specific microphone audio contracts change the configuration
+    // descriptor. Bump the revision so Windows does not reuse a cached shape.
+    .bcdDevice = 0x0155,
 
     .iManufacturer = 0x01,
     .iProduct = 0x02,
@@ -381,8 +383,8 @@ uint8_t descriptor_configuration[] = {
     0x05, // bDescriptorType (ENDPOINT)
     0x82, // bEndpointAddress: IN EP2
     0x05, // bmAttributes: Isochronous, Asynchronous
-    CFG_TUD_AUDIO_FUNC_1_FORMAT_1_EP_SZ_IN & 0xFF,
-    (CFG_TUD_AUDIO_FUNC_1_FORMAT_1_EP_SZ_IN >> 8) & 0xFF,
+    CONTROLLER_MIC_MONO_EP_SIZE & 0xFF,
+    (CONTROLLER_MIC_MONO_EP_SIZE >> 8) & 0xFF,
     0x01, // bInterval: 1
     0x00, // bRefresh
     0x00, // bSynchAddress
@@ -606,6 +608,10 @@ TU_VERIFY_STATIC(sizeof(descriptor_configuration) == CONFIG_TOTAL_LEN_STANDARD, 
 
 static CFG_TUD_MEM_ALIGN uint8_t descriptor_configuration_xusb[sizeof(descriptor_configuration) + XUSB360_CONFIG_EXTRA_LEN];
 static uint16_t descriptor_configuration_xusb_len = 0;
+static CFG_TUD_MEM_ALIGN uint8_t descriptor_configuration_dualsense_edge[
+    sizeof(descriptor_configuration) + DUALSENSE_EDGE_AUDIO_EXTRA_LEN
+];
+static uint16_t descriptor_configuration_dualsense_edge_len = 0;
 
 static uint8_t const desc_xusb360_gamepad_interface[] = {
     // --- INTERFACE DESCRIPTOR: XUSB 360-compatible gamepad ---
@@ -747,6 +753,73 @@ static uint16_t build_xusb_configuration_descriptor(void) {
     return dest;
 }
 
+static uint16_t build_dualsense_edge_configuration_descriptor(void) {
+    if (descriptor_configuration_dualsense_edge_len != 0) {
+        return descriptor_configuration_dualsense_edge_len;
+    }
+
+    uint16_t dest = 0;
+    uint8_t source_interface = 0xff;
+    for (size_t offset = 0; offset + 2 <= sizeof(descriptor_configuration);) {
+        uint8_t length = descriptor_configuration[offset];
+        if (length < 2 || offset + length > sizeof(descriptor_configuration)) {
+            return 0;
+        }
+
+        uint8_t descriptor[255];
+        memcpy(descriptor, descriptor_configuration + offset, length);
+        const uint8_t descriptor_type = descriptor[1];
+        if (descriptor_type == TUSB_DESC_INTERFACE && length >= 9) {
+            source_interface = descriptor[2];
+        } else if (source_interface == 0 && descriptor_type == 0x24 && length >= 3) {
+            if (descriptor[2] == 0x01 && length >= 7) {
+                const uint16_t audio_control_length = (uint16_t)(descriptor[5] | (descriptor[6] << 8));
+                const uint16_t edge_audio_control_length = (uint16_t)(audio_control_length + 1);
+                descriptor[5] = (uint8_t)(edge_audio_control_length & 0xff);
+                descriptor[6] = (uint8_t)((edge_audio_control_length >> 8) & 0xff);
+            } else if (descriptor[2] == 0x02 && length >= 12 && descriptor[3] == 0x04) {
+                descriptor[7] = 0x02;
+                descriptor[8] = 0x03;
+                descriptor[9] = 0x00;
+            } else if (descriptor[2] == 0x06 && length == 9 && descriptor[3] == 0x05) {
+                memmove(descriptor + 9, descriptor + 8, 1);
+                descriptor[8] = 0x00;
+                descriptor[0] = 10;
+                length = 10;
+            }
+        } else if (
+            source_interface == 2
+            && descriptor_type == 0x24
+            && length >= 11
+            && descriptor[2] == 0x02
+            && descriptor[3] == 0x01
+        ) {
+            descriptor[4] = 0x02;
+        } else if (
+            source_interface == 2
+            && descriptor_type == TUSB_DESC_ENDPOINT
+            && length >= 7
+            && descriptor[2] == 0x82
+        ) {
+            descriptor[4] = (uint8_t)(CFG_TUD_AUDIO_FUNC_1_FORMAT_1_EP_SZ_IN & 0xff);
+            descriptor[5] = (uint8_t)((CFG_TUD_AUDIO_FUNC_1_FORMAT_1_EP_SZ_IN >> 8) & 0xff);
+        }
+
+        if (dest + length > sizeof(descriptor_configuration_dualsense_edge)) {
+            return 0;
+        }
+        memcpy(descriptor_configuration_dualsense_edge + dest, descriptor, length);
+        dest = (uint16_t)(dest + length);
+        offset += descriptor_configuration[offset];
+    }
+
+    descriptor_configuration_dualsense_edge[2] = (uint8_t)(dest & 0xff);
+    descriptor_configuration_dualsense_edge[3] = (uint8_t)((dest >> 8) & 0xff);
+    apply_gamepad_hid_runtime_configuration(descriptor_configuration_dualsense_edge, dest);
+    descriptor_configuration_dualsense_edge_len = dest;
+    return dest;
+}
+
 // Invoked when received GET CONFIGURATION DESCRIPTOR
 // Application return pointer to descriptor
 // Descriptor contents must exist long enough for transfer to complete
@@ -758,6 +831,15 @@ uint8_t const *tud_descriptor_configuration_cb(uint8_t index) {
         }
         if (descriptor_configuration_xusb_len != 0) {
             return descriptor_configuration_xusb;
+        }
+    }
+
+    if (host_persona_active() == HostPersonaModeDualSenseEdge) {
+        if (descriptor_configuration_dualsense_edge_len == 0) {
+            (void)build_dualsense_edge_configuration_descriptor();
+        }
+        if (descriptor_configuration_dualsense_edge_len != 0) {
+            return descriptor_configuration_dualsense_edge;
         }
     }
 

--- a/tests/firmware/firmware_logic_tests.cpp
+++ b/tests/firmware/firmware_logic_tests.cpp
@@ -295,6 +295,14 @@ void dualsense_audio_section_mask_matches_0x39_layout() {
     EXPECT_EQ(ds5::output::controller_microphone_transport_mask(false), 0x02);
 }
 
+void dualsense_mic_volume_percent_uses_0x30_ceiling() {
+    EXPECT_EQ(mic_volume_from_percent(0), 0x00);
+    EXPECT_EQ(mic_volume_from_percent(50), 0x18);
+    EXPECT_EQ(mic_volume_from_percent(75), 0x24);
+    EXPECT_EQ(mic_volume_from_percent(100), 0x30);
+    EXPECT_EQ(mic_volume_from_percent(255), 0x30);
+}
+
 void classic_rumble_delivery_is_bounded_and_protects_managed_stop() {
     using ds5::classic_rumble::AdmissionResult;
     using ds5::classic_rumble::DeliveryKind;
@@ -1537,6 +1545,7 @@ std::vector<TestCase> tests{
     {"scheduler fifo orders host output and audio by arrival", scheduler_fifo_orders_host_output_and_audio_by_arrival},
     {"scheduler fifo timestamp order is wrap safe", scheduler_fifo_timestamp_order_is_wrap_safe},
     {"dualsense audio section mask matches 0x39 layout", dualsense_audio_section_mask_matches_0x39_layout},
+    {"dualsense mic volume percent uses 0x30 ceiling", dualsense_mic_volume_percent_uses_0x30_ceiling},
     {"classic rumble delivery is bounded and protects managed stop", classic_rumble_delivery_is_bounded_and_protects_managed_stop},
     {"classic rumble coalesces latest active without crossing stop", classic_rumble_coalesces_latest_active_without_crossing_stop},
     {"packet compositor initializes bluetooth report and wraps sequence", packet_compositor_initializes_bluetooth_report_and_wraps_sequence},

--- a/tests/firmware/usb_descriptor_migration_test.cpp
+++ b/tests/firmware/usb_descriptor_migration_test.cpp
@@ -11,8 +11,8 @@
 
 namespace {
 
-constexpr uint16_t kExpectedUsbDeviceRevision = 0x0154;
-constexpr uint64_t kExpectedCompanionDescriptorHash = 0x93930b64f2ccbc7cull;
+constexpr uint16_t kExpectedUsbDeviceRevision = 0x0155;
+constexpr uint64_t kExpectedCompanionDescriptorHash = 0xbf4f9410baf82bc4ull;
 
 std::string read_text(std::filesystem::path const &path) {
     std::ifstream input(path, std::ios::binary);
@@ -247,6 +247,8 @@ void assert_dualsense_edge_persona_is_edge_facing(
     const auto cmake = read_text(source_root / "CMakeLists.txt");
     const auto companion_cpp = read_text(source_root / "src" / "companion.cpp");
     const auto host_persona_h = read_text(source_root / "src" / "persona" / "host_persona.h");
+    const auto audio_cpp = read_text(source_root / "src" / "audio.cpp");
+    const auto tusb_config_h = read_text(source_root / "src" / "tusb_config.h");
 
     if (
         cmake.find("ENABLE_DSE") != std::string::npos
@@ -260,12 +262,12 @@ void assert_dualsense_edge_persona_is_edge_facing(
     if (
         source.find("#define DUALSENSE_EDGE_VENDOR_ID 0x054C") == std::string::npos
         || source.find("#define DUALSENSE_EDGE_PRODUCT_ID 0x0DF2") == std::string::npos
-        || source.find("#define DUALSENSE_EDGE_USB_BCD_DEVICE 0x0100") == std::string::npos
+        || source.find("#define DUALSENSE_EDGE_USB_BCD_DEVICE 0x0101") == std::string::npos
         || source.find("#define DUALSENSE_EDGE_STRING_PRODUCT \"DualSense Edge Wireless Controller\"") == std::string::npos
         || source.find("#define DUALSENSE_EDGE_HID_REPORT_DESC_LEN 0x01B5") == std::string::npos
         || source.find("TU_VERIFY_STATIC(sizeof(desc_hid_report_dse) == DUALSENSE_EDGE_HID_REPORT_DESC_LEN") == std::string::npos
     ) {
-        throw std::runtime_error("DualSense Edge USB identity and report descriptor must match the pinned stock contract");
+        throw std::runtime_error("DualSense Edge USB identity, report descriptor, and cache revision must match the pinned contract");
     }
 
     const std::string edge_descriptor = extract_between(
@@ -303,6 +305,20 @@ void assert_dualsense_edge_persona_is_edge_facing(
     ) {
         throw std::runtime_error("DualSense Edge persona must select its runtime device, HID, and product descriptors together");
     }
+
+    if (
+        tusb_config_h.find("#define CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX              2") == std::string::npos
+        || source.find("#define CONTROLLER_MIC_MONO_EP_SIZE 0x0060") == std::string::npos
+        || source.find("build_dualsense_edge_configuration_descriptor") == std::string::npos
+        || source.find("descriptor_configuration_dualsense_edge") == std::string::npos
+        || source.find("source_interface == 2") == std::string::npos
+        || audio_cpp.find("host_persona_active() == HostPersonaModeDualSenseEdge ? 2 : 1") == std::string::npos
+        || audio_cpp.find("host_mic_usb_channel_count()") == std::string::npos
+    ) {
+        throw std::runtime_error(
+            "DualSense Edge must expose its stereo microphone contract without changing the mono contract of other personas"
+        );
+    }
 }
 
 void assert_xusb_persona_strings_are_xbox_facing(std::string const &source) {
@@ -314,7 +330,7 @@ void assert_xusb_persona_strings_are_xbox_facing(std::string const &source) {
         throw std::runtime_error("Xbox persona must expose a non-Sony composite-safe USB product ID");
     }
 
-    if (source.find("#define XUSB360_USB_BCD_DEVICE 0x0156") == std::string::npos) {
+    if (source.find("#define XUSB360_USB_BCD_DEVICE 0x0157") == std::string::npos) {
         throw std::runtime_error("Xbox persona USB revision must be bumped for Windows descriptor cache separation");
     }
 
@@ -366,8 +382,8 @@ void assert_ds4_persona_identity_is_ds4_facing(std::string const &source) {
         throw std::runtime_error("DS4 persona must expose the DS4 v2 USB product ID");
     }
 
-    if (source.find("#define DS4_USB_BCD_DEVICE 0x0103") == std::string::npos) {
-        throw std::runtime_error("DS4 persona must bump its USB revision for the remote-wake descriptor");
+    if (source.find("#define DS4_USB_BCD_DEVICE 0x0104") == std::string::npos) {
+        throw std::runtime_error("DS4 persona must bump its USB revision when its shared audio descriptor changes");
     }
 
     if (source.find("#define DS4_HID_REPORT_DESC_LEN 0x01FB") == std::string::npos) {


### PR DESCRIPTION
## Summary

- isolate the DualSense Edge stereo microphone USB contract while preserving mono capture for DualSense, DualShock 4, and Xbox personas
- recognize all supported persona audio endpoints in the companion microphone and speaker tests
- correct the DualSense controller microphone volume ceiling from `0x40` to `0x30`

## Why

DualSense Edge requires a different enumerated microphone channel contract, while the companion's browser-based test path did not recognize the Xbox endpoint label. The controller microphone output report also used the enable-flag value as its volume ceiling.

## User impact

Microphone capture and testing now work consistently across DS, DSE, DS4, and Xbox personas. DSE gets its required stereo endpoint, the other personas remain mono, and microphone level control stays within the controller's native range.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run build:app`
- standard Pico firmware build
- Waveshare firmware build
