### PR TITLE
fix(bt): don't idle-disconnect while audio is playing to the controller

### DIFF
--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -4062,6 +4062,16 @@ static __attribute__((noinline)) void l2cap_packet_handler_cold(
             if (mute[1]) { // Microphone mute is enabled.
                 return;
             }
+            // Audio actively routed to the controller (a movie or music
+            // through the 3.5 mm headset jack) means the device is in use
+            // even with no button input -- don't idle-disconnect and cut the
+            // audio. Reset the idle clock so the full timeout starts fresh
+            // once playback stops, matching how a button press resets it.
+            // Same signal the RSSI idle gate and output-route protection use.
+            if (audio_output_route_protected()) {
+                inactive_time = now_us;
+                return;
+            }
             if (!meaningful_input_activity && now_us - inactive_time > idle_disconnect_timeout_us()) {
                 DS5_LOG("disconnect when inactive\n");
                 inactive_time = now_us;

--- a/tests/firmware/usb_descriptor_migration_test.cpp
+++ b/tests/firmware/usb_descriptor_migration_test.cpp
@@ -1233,6 +1233,21 @@ void assert_bluetooth_pairing_and_reconnect_policy(std::filesystem::path const &
         "// Inactivity detection.",
         input_activity
     );
+    // The idle-disconnect path must not fire while audio is actively routed
+    // to the controller (a movie or music through the headset jack) -- same
+    // guard the RSSI idle gate uses. It sits after the mic-mute carve-out and
+    // before the timeout comparison, and resets the idle clock so the full
+    // timeout restarts once playback stops.
+    const std::string idle_block = idle_disconnect == std::string::npos
+        ? std::string()
+        : bt_cpp.substr(
+            idle_disconnect,
+            bt_cpp.find("BtControllerDisconnectIntentIdleTimeout", idle_disconnect)
+                - idle_disconnect
+        );
+    const auto idle_mic_mute = idle_block.find("if (mute[1])");
+    const auto idle_audio_guard = idle_block.find("if (audio_output_route_protected())");
+    const auto idle_timeout_cmp = idle_block.find("now_us - inactive_time > idle_disconnect_timeout_us()");
     if (
         bt_cpp.find("RSSI_POLL_INTERVAL_US") != std::string::npos
         || bt_cpp.find("#define RSSI_INPUT_IDLE_GRACE_US 5000000ull")
@@ -1253,9 +1268,17 @@ void assert_bluetooth_pairing_and_reconnect_policy(std::filesystem::path const &
             == std::string::npos
         || bt_cpp.find("uint64_t inactive_time = 0;")
             == std::string::npos
+        || idle_mic_mute == std::string::npos
+        || idle_audio_guard == std::string::npos
+        || idle_timeout_cmp == std::string::npos
+        || !(idle_mic_mute < idle_audio_guard && idle_audio_guard < idle_timeout_cmp)
+        || idle_block.find(
+            "if (audio_output_route_protected()) {\n                inactive_time = now_us;\n                return;\n            }"
+        ) == std::string::npos
     ) {
         throw std::runtime_error(
-            "RSSI sampling must remain input-idle, audio-safe, and bounded per idle epoch"
+            "RSSI sampling must remain input-idle, audio-safe, and bounded per idle epoch; "
+            "idle disconnect must skip while audio is routed to the controller"
         );
     }
 


### PR DESCRIPTION
## Problem

Idle Disconnect drops the controller after its timeout based only on the
absence of meaningful HID input. Audio playback is not considered.

Using the controller as a headset -- a headset plugged into the 3.5 mm jack,
watching a movie or listening to music -- means no button input for long
stretches. The controller idle-disconnects mid-playback and the audio cuts
out. The only workarounds are disabling Idle Disconnect or setting an
impractically long timeout.

## Change

One condition in `src/bt.cpp`, in the inactivity check in
`l2cap_packet_handler_cold()`:

```cpp
    // Inactivity detection.
    if (mute[1]) { // Microphone mute is enabled.
        return;
    }
    if (audio_output_route_protected()) {
        inactive_time = now_us;
        return;
    }
    if (!meaningful_input_activity && now_us - inactive_time > idle_disconnect_timeout_us()) {
        ...
    }
```

`audio_output_route_protected()` (`audio_recent() || usb_speaker_streaming_active()`)
already exists in the same file and is already used for the RSSI idle gate
and output-route protection. This reuses it rather than adding a new signal.

The idle clock is reset (rather than simply returning) so the full timeout
restarts when playback stops -- matching how a button press resets it.
Returning without the reset would leave a long playback session about to trip
the timeout the moment audio ends.

Placement is after the existing `mute[1]` mic-mute carve-out and before the
timeout comparison. It mirrors that carve-out in location and shape.

## Scope

- No new state, no timer, no allocation.
- No companion command, no protocol change, no `COMMAND_ID`, no
  `PROTOCOL_MINOR` bump.
- No UI change. The existing Idle Disconnect enable toggle and timeout
  selector behave exactly as before; they simply stop firing during
  playback.
- Runs only on HID interrupt packets, the same cadence as the existing
  check.

## Testing

`tests/firmware/usb_descriptor_migration_test.cpp` -- the RSSI-idle source
assertion is extended to require the new guard, its exact body, and its
ordering between the mic-mute carve-out and the timeout comparison. All
firmware host-side suites pass.

Hardware (Waveshare RP2350B-Plus-W, Idle Disconnect set to 1 minute):

1. Headset in the jack, continuous playback, no controller input -- stays
   connected well past the timeout, audio uninterrupted.
2. Playback stopped, still no input -- disconnects roughly one timeout period
   after audio stopped, not immediately.
3. No audio and no input -- disconnects at the timeout, unchanged from
   before.
4. Mic mute still independently suppresses idle disconnect.
