### PR TITLE
feat(companion): auto-switch Windows audio output on controller headset jack

### DIFF
--- a/companion/native/AudioHelper/EndpointManager.cs
+++ b/companion/native/AudioHelper/EndpointManager.cs
@@ -93,6 +93,46 @@ sealed class EndpointManager
         Console.Error.WriteLine($"status: default-render-set device='{device.FriendlyName}' persona='{hostPersonaMode ?? "auto"}'");
     }
 
+    // Set the default render endpoint to the first active device whose
+    // FriendlyName matches one of the supplied candidate substrings, tried in
+    // order. Used by the companion's headset-audio auto-switch feature for the
+    // "nothing in the controller jack" target (a fixed fallback device such as
+    // the TV / HDMI endpoint), which --set-default-render-bridge can't express.
+    // Throws (non-zero exit) if none of the candidates matches an active
+    // endpoint, so the caller's retry logic can react.
+    public static void SetDefaultRenderEndpointByName(string candidates)
+    {
+        var wanted = candidates
+            .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (wanted.Length == 0)
+        {
+            throw new ArgumentException("No candidate device name supplied.", nameof(candidates));
+        }
+
+        using var enumerator = new MMDeviceEnumerator();
+        var devices = enumerator
+            .EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active)
+            .ToArray();
+
+        foreach (var name in wanted)
+        {
+            var match = devices.FirstOrDefault(device =>
+                    string.Equals(device.FriendlyName, name, StringComparison.OrdinalIgnoreCase))
+                ?? devices.FirstOrDefault(device =>
+                    device.FriendlyName.Contains(name, StringComparison.OrdinalIgnoreCase));
+            if (match is not null)
+            {
+                SetDefaultRenderEndpoint(match);
+                Console.Error.WriteLine($"status: default-render-set device='{match.FriendlyName}' matched='{name}'");
+                return;
+            }
+        }
+
+        var available = string.Join(", ", devices.Select(device => $"'{device.FriendlyName}'"));
+        throw new InvalidOperationException(
+            $"No active render endpoint matched any of [{string.Join(", ", wanted.Select(n => $"'{n}'"))}]. Available endpoints: {available}");
+    }
+
     public static MMDevice SelectCaptureEndpoint(MMDeviceEnumerator enumerator, string? deviceName)
     {
         var devices = enumerator
@@ -201,6 +241,24 @@ sealed class EndpointManager
         }
 
         return null;
+    }
+
+    // Emit the active render endpoints as JSON on stdout, for the companion's
+    // "Auto Switch Audio" fallback-device dropdown:
+    //   [ { "name": "<FriendlyName>", "isBridge": true|false }, ... ]
+    // `isBridge` flags the DS5 Bridge / controller endpoint so the companion
+    // can tell it apart from real output devices (and auto-pick the fallback
+    // when there's exactly one non-bridge endpoint). Selection is still
+    // matched back by name substring, same as SetDefaultRenderEndpointByName.
+    public static void ListRenderEndpoints()
+    {
+        using var enumerator = new MMDeviceEnumerator();
+        var entries = enumerator
+            .EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active)
+            .Select(device => new { name = device.FriendlyName, isBridge = IsKnownBridgeEndpoint(device) })
+            .OrderBy(entry => entry.name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        Console.WriteLine(JsonSerializer.Serialize(entries));
     }
 
     public static void ListDevices()

--- a/companion/native/AudioHelper/Program.cs
+++ b/companion/native/AudioHelper/Program.cs
@@ -80,6 +80,16 @@ if (options.SetDefaultRenderBridge)
     EndpointManager.SetDefaultRenderBridgeEndpoint(options.BridgePersona);
     return;
 }
+if (options.SetDefaultRender)
+{
+    EndpointManager.SetDefaultRenderEndpointByName(options.DeviceName ?? string.Empty);
+    return;
+}
+if (options.ListRenderEndpoints)
+{
+    EndpointManager.ListRenderEndpoints();
+    return;
+}
 
 using var helper = new AudioHelper(options);
 await helper.RunAsync();
@@ -2751,6 +2761,8 @@ sealed record HelperOptions(
     bool PlayTestHaptics,
     bool DefaultRenderStatus,
     bool SetDefaultRenderBridge,
+    bool SetDefaultRender,
+    bool ListRenderEndpoints,
     string? BridgePersona,
     bool HapticsOnly,
     bool StdoutOnly,
@@ -2815,6 +2827,8 @@ sealed record HelperOptions(
         var playTestHaptics = false;
         var defaultRenderStatus = false;
         var setDefaultRenderBridge = false;
+        var setDefaultRender = false;
+        var listRenderEndpoints = false;
         string? bridgePersona = null;
         var captureDumpOnly = false;
         var hapticsOnly = false;
@@ -2971,6 +2985,12 @@ sealed record HelperOptions(
                 case "--set-default-render-bridge":
                     setDefaultRenderBridge = true;
                     break;
+                case "--set-default-render":
+                    setDefaultRender = true;
+                    break;
+                case "--list-render-endpoints":
+                    listRenderEndpoints = true;
+                    break;
                 case "--bridge-persona" when index + 1 < args.Length:
                     bridgePersona = args[++index];
                     break;
@@ -3005,6 +3025,8 @@ sealed record HelperOptions(
             playTestHaptics,
             defaultRenderStatus,
             setDefaultRenderBridge,
+            setDefaultRender,
+            listRenderEndpoints,
             bridgePersona,
             hapticsOnly,
             stdoutOnly,

--- a/companion/src/main/audio-helper.ts
+++ b/companion/src/main/audio-helper.ts
@@ -961,6 +961,57 @@ export async function setDefaultRenderBridgeEndpoint(mode: HostPersonaMode): Pro
   ], HELPER_ENDPOINT_ENUMERATION_TIMEOUT_MS);
 }
 
+// Set the Windows default render endpoint to the first active device whose
+// name matches one of `candidateNames` (tried in order). Used by the
+// "Auto Route Audio" feature for the "nothing plugged into the controller
+// jack" target -- the user's chosen fallback device, which
+// --set-default-render-bridge can't express. Rejects if none of the
+// candidates matches an active endpoint.
+export async function setDefaultRenderEndpointByName(candidateNames: string[]): Promise<void> {
+  const candidates = candidateNames.map((name) => name.trim()).filter((name) => name.length > 0);
+  if (candidates.length === 0) {
+    throw new Error('setDefaultRenderEndpointByName: no candidate device name supplied.');
+  }
+  await runAudioHelperCommand([
+    '--set-default-render',
+    '--device-name',
+    candidates.join(';'),
+    ...bridgeTargetArgs()
+  ], HELPER_ENDPOINT_ENUMERATION_TIMEOUT_MS);
+}
+
+export interface RenderEndpointInfo {
+  name: string;
+  isBridge: boolean;
+}
+
+// Active Windows render endpoints, for the "Auto Switch Audio" fallback-device
+// dropdown. `isBridge` flags the controller's own endpoint. Returns [] on any
+// helper failure so the settings menu still renders (with just the saved
+// value, if any).
+export async function listRenderEndpoints(): Promise<RenderEndpointInfo[]> {
+  try {
+    const result = await runAudioHelperCommand(
+      ['--list-render-endpoints'],
+      HELPER_ENDPOINT_ENUMERATION_TIMEOUT_MS
+    );
+    const parsed: unknown = JSON.parse(result.stdout.trim() || '[]');
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed
+      .filter((entry): entry is { name: unknown; isBridge?: unknown } => (
+        typeof entry === 'object' && entry !== null && typeof (entry as { name?: unknown }).name === 'string'
+      ))
+      .map((entry) => ({
+        name: entry.name as string,
+        isBridge: (entry as { isBridge?: unknown }).isBridge === true
+      }));
+  } catch {
+    return [];
+  }
+}
+
 export class MicKeepaliveEngine extends EventEmitter {
   private process: ChildProcess | null = null;
   private starting: Promise<void> | null = null;

--- a/companion/src/main/bridge-service.test.ts
+++ b/companion/src/main/bridge-service.test.ts
@@ -546,9 +546,10 @@ function firmwareLogReport(bytes: number[], options: {
 function createService(initialSettings?: Parameters<SettingsStore['update']>[0]): { service: BridgeService; tempDir: string } {
   const tempDir = mkdtempSync(path.join(tmpdir(), 'ds5-bridge-companion-'));
   const settingsStore = new SettingsStore(tempDir);
-  if (initialSettings) {
-    settingsStore.update(initialSettings);
-  }
+  // "Auto Switch Audio" is off by default. Keep it explicit here so a future
+  // default change can't make unrelated polling tests spawn the real
+  // AudioHelper; the dedicated tests opt in.
+  settingsStore.update({ headsetAudioAutoSwitchEnabled: false, ...initialSettings });
   return {
     service: new BridgeService(settingsStore),
     tempDir
@@ -1427,6 +1428,186 @@ describe('BridgeService', () => {
       [COMMAND_ID.SET_LIGHTBAR_COLOR, 90],
       [COMMAND_ID.SET_LIGHTBAR_OVERRIDE, 0]
     ]);
+  });
+
+  describe('Auto Switch Audio on Jack', () => {
+    const FALLBACK = '4 - Beyo TV (2- AMD High Definition Audio Device)';
+
+    function attachRenderMocks(
+      service: BridgeService,
+      endpoints: Array<{ name: string; isBridge: boolean }> = [
+        { name: FALLBACK, isBridge: false },
+        { name: 'Speakers (4- DualSense Wireless Controller)', isBridge: true }
+      ]
+    ) {
+      const setDefaultRenderBridgeEndpoint = vi.fn(async () => undefined);
+      const setDefaultRenderEndpointByName = vi.fn(async () => undefined);
+      const getDefaultRenderEndpointStatus = vi.fn(async () => ({
+        deviceName: 'Speakers (4- DualSense Wireless Controller)',
+        isBridgeEndpoint: true
+      }));
+      const internals = service as unknown as {
+        setDefaultRenderBridgeEndpoint: typeof setDefaultRenderBridgeEndpoint;
+        setDefaultRenderEndpointByName: typeof setDefaultRenderEndpointByName;
+        getDefaultRenderEndpointStatus: typeof getDefaultRenderEndpointStatus;
+        cachedRenderEndpoints: Array<{ name: string; isBridge: boolean }>;
+      };
+      internals.setDefaultRenderBridgeEndpoint = setDefaultRenderBridgeEndpoint;
+      internals.setDefaultRenderEndpointByName = setDefaultRenderEndpointByName;
+      internals.getDefaultRenderEndpointStatus = getDefaultRenderEndpointStatus;
+      internals.cachedRenderEndpoints = endpoints;
+      return { setDefaultRenderBridgeEndpoint, setDefaultRenderEndpointByName, getDefaultRenderEndpointStatus };
+    }
+
+    it('routes to the chosen fallback when the jack is empty and to the controller when a headset is plugged in', async () => {
+      const service = serviceFixture({
+        headsetAudioAutoSwitchEnabled: true,
+        headsetAudioFallbackDevice: FALLBACK
+      });
+      const device = new MockHidDevice();
+      device.status = statusReport({ controllerConnected: true, hostPersonaMode: 'dualsense' });
+      device.audioStatusReports = [audioStatusReport({ headsetPlugged: false })];
+      hidMock.state.devicesList = [companionDeviceInfo()];
+      hidMock.state.openDevices.set('companion-path', device);
+      const mocks = attachRenderMocks(service);
+
+      // First poll: empty jack, adopted immediately (no prior acted state).
+      await poll(service);
+      expect(mocks.setDefaultRenderEndpointByName).toHaveBeenCalledOnce();
+      expect(mocks.setDefaultRenderEndpointByName).toHaveBeenCalledWith([FALLBACK]);
+      expect(mocks.setDefaultRenderBridgeEndpoint).not.toHaveBeenCalled();
+
+      // Headset plugged in: needs to hold for the debounce window before acting.
+      device.audioStatusReports = [audioStatusReport({ headsetPlugged: true })];
+      await poll(service);
+      expect(mocks.setDefaultRenderBridgeEndpoint).not.toHaveBeenCalled();
+
+      device.audioStatusReports = [audioStatusReport({ headsetPlugged: true })];
+      await poll(service);
+      expect(mocks.setDefaultRenderBridgeEndpoint).toHaveBeenCalledOnce();
+      expect(mocks.setDefaultRenderBridgeEndpoint).toHaveBeenCalledWith('dualsense');
+
+      // Unplug: again debounced, then routes back to the fallback.
+      mocks.setDefaultRenderEndpointByName.mockClear();
+      device.audioStatusReports = [audioStatusReport({ headsetPlugged: false })];
+      await poll(service);
+      expect(mocks.setDefaultRenderEndpointByName).not.toHaveBeenCalled();
+      device.audioStatusReports = [audioStatusReport({ headsetPlugged: false })];
+      await poll(service);
+      expect(mocks.setDefaultRenderEndpointByName).toHaveBeenCalledOnce();
+    });
+
+    it('does nothing when the toggle is off', async () => {
+      const service = serviceFixture({ headsetAudioAutoSwitchEnabled: false });
+      const device = new MockHidDevice();
+      device.status = statusReport({ controllerConnected: true });
+      device.audioStatusReports = [
+        audioStatusReport({ headsetPlugged: false }),
+        audioStatusReport({ headsetPlugged: true }),
+        audioStatusReport({ headsetPlugged: true })
+      ];
+      hidMock.state.devicesList = [companionDeviceInfo()];
+      hidMock.state.openDevices.set('companion-path', device);
+      const mocks = attachRenderMocks(service);
+
+      await poll(service);
+      await poll(service);
+      await poll(service);
+      expect(mocks.setDefaultRenderEndpointByName).not.toHaveBeenCalled();
+      expect(mocks.setDefaultRenderBridgeEndpoint).not.toHaveBeenCalled();
+    });
+
+    it('auto-resolves the fallback to the only non-controller output when none is chosen', async () => {
+      const service = serviceFixture({
+        headsetAudioAutoSwitchEnabled: true,
+        headsetAudioFallbackDevice: ''
+      });
+      const device = new MockHidDevice();
+      device.status = statusReport({ controllerConnected: true, hostPersonaMode: 'dualsense' });
+      device.audioStatusReports = [audioStatusReport({ headsetPlugged: false })];
+      hidMock.state.devicesList = [companionDeviceInfo()];
+      hidMock.state.openDevices.set('companion-path', device);
+      const mocks = attachRenderMocks(service);
+
+      await poll(service);
+      expect(mocks.setDefaultRenderEndpointByName).toHaveBeenCalledWith([FALLBACK]);
+    });
+
+    it('stays idle when the toggle is on but two non-controller outputs exist and none is chosen', async () => {
+      const service = serviceFixture({
+        headsetAudioAutoSwitchEnabled: true,
+        headsetAudioFallbackDevice: ''
+      });
+      const device = new MockHidDevice();
+      device.status = statusReport({ controllerConnected: true, hostPersonaMode: 'dualsense' });
+      device.audioStatusReports = [
+        audioStatusReport({ headsetPlugged: false }),
+        audioStatusReport({ headsetPlugged: false })
+      ];
+      hidMock.state.devicesList = [companionDeviceInfo()];
+      hidMock.state.openDevices.set('companion-path', device);
+      const mocks = attachRenderMocks(service, [
+        { name: 'Speakers (Realtek)', isBridge: false },
+        { name: FALLBACK, isBridge: false },
+        { name: 'Speakers (4- DualSense Wireless Controller)', isBridge: true }
+      ]);
+
+      await poll(service);
+      await poll(service);
+      expect(mocks.setDefaultRenderEndpointByName).not.toHaveBeenCalled();
+      expect(mocks.setDefaultRenderBridgeEndpoint).not.toHaveBeenCalled();
+    });
+
+    it('pulls the default off the controller when the jack stays empty', async () => {
+      const service = serviceFixture({
+        headsetAudioAutoSwitchEnabled: true,
+        headsetAudioFallbackDevice: FALLBACK
+      });
+      const device = new MockHidDevice();
+      device.status = statusReport({ controllerConnected: true, hostPersonaMode: 'dualsense' });
+      device.audioStatusReports = [audioStatusReport({ headsetPlugged: false })];
+      hidMock.state.devicesList = [companionDeviceInfo()];
+      hidMock.state.openDevices.set('companion-path', device);
+      const mocks = attachRenderMocks(service);
+
+      await poll(service); // adopts empty-jack, routes to fallback once
+      mocks.setDefaultRenderEndpointByName.mockClear();
+
+      // Windows promoted the controller again; the empty-jack correction path
+      // (getDefaultRenderEndpointStatus -> isBridgeEndpoint -> re-route) fires.
+      device.audioStatusReports = [audioStatusReport({ headsetPlugged: false })];
+      await poll(service);
+      expect(mocks.getDefaultRenderEndpointStatus).toHaveBeenCalled();
+      expect(mocks.setDefaultRenderEndpointByName).toHaveBeenCalledOnce();
+      expect(mocks.setDefaultRenderEndpointByName).toHaveBeenCalledWith([FALLBACK]);
+    });
+
+    it('stays dormant during an RDP session', async () => {
+      const service = serviceFixture({
+        headsetAudioAutoSwitchEnabled: true,
+        headsetAudioFallbackDevice: FALLBACK
+      });
+      const device = new MockHidDevice();
+      device.status = statusReport({ controllerConnected: true });
+      device.audioStatusReports = [audioStatusReport({ headsetPlugged: false })];
+      hidMock.state.devicesList = [companionDeviceInfo()];
+      hidMock.state.openDevices.set('companion-path', device);
+      const mocks = attachRenderMocks(service);
+
+      const previousSessionName = process.env.SESSIONNAME;
+      process.env.SESSIONNAME = 'RDP-Tcp#3';
+      try {
+        await poll(service);
+        expect(mocks.setDefaultRenderEndpointByName).not.toHaveBeenCalled();
+        expect(mocks.setDefaultRenderBridgeEndpoint).not.toHaveBeenCalled();
+      } finally {
+        if (previousSessionName === undefined) {
+          delete process.env.SESSIONNAME;
+        } else {
+          process.env.SESSIONNAME = previousSessionName;
+        }
+      }
+    });
   });
 
   it('sends speaker volume as firmware gain', async () => {

--- a/companion/src/main/bridge-service.ts
+++ b/companion/src/main/bridge-service.ts
@@ -93,7 +93,10 @@ import {
   playBridgeSpeakerTestTone,
   getDefaultRenderEndpointStatus,
   setDefaultRenderBridgeEndpoint,
+  setDefaultRenderEndpointByName,
+  listRenderEndpoints,
   listBridges,
+  type RenderEndpointInfo,
   setAudioHelperBridgeTarget,
   type BridgeCensus,
   type DefaultRenderEndpointStatus,
@@ -144,6 +147,10 @@ const HOST_PERSONA_DEFAULT_RENDER_RESTORE_GRACE_MS = 4000;
 const MIN_IDLE_DISCONNECT_TIMEOUT_MINUTES = 1;
 const MAX_IDLE_DISCONNECT_TIMEOUT_MINUTES = 120;
 const CONTROLLER_POWER_SAVING_CAP_PERCENT = 60;
+// "Auto Route Audio": a changed jack state must hold this many consecutive
+// audio-status polls (~500 ms each) before the feature acts, so a
+// marginal/chattering 3.5 mm plug doesn't flip the default output repeatedly.
+const HEADSET_AUDIO_JACK_DEBOUNCE_POLLS = 2;
 const STANDARD_FEEDBACK_GAIN_PERCENT = 200;
 const BOOSTED_FEEDBACK_GAIN_PERCENT = 500;
 const HAPTICS_STEP = 20;
@@ -925,6 +932,7 @@ function formatAudioStats(stats: AudioDebugStatsPayload): string {
   ].join(' ');
 }
 
+
 function triggerTraceStageLabel(stage: number): string {
   switch (stage) {
     case 1:
@@ -1296,6 +1304,21 @@ export class BridgeService extends EventEmitter {
   private lastDefaultRenderEndpointStatus: DefaultRenderEndpointStatus | null = null;
   private lastDefaultRenderEndpointStatusAt = 0;
   private controllerPowerSavingActive: boolean | null = null;
+  // "Auto Switch Audio on Jack" feature: route
+  // Windows' default output to the controller only while a headset is in its
+  // 3.5 mm jack, otherwise to the user's chosen fallback device
+  // (settings.headsetAudioFallbackDevice; '' = feature off).
+  // `headsetJackActedState` is the jack state the feature last drove a switch
+  // for; the pending/count pair debounces the raw firmware bit (byte 53 bit 0
+  // is an unfiltered pass-through -- no firmware debounce anywhere).
+  private headsetJackActedState: boolean | null = null;
+  private headsetJackPending: boolean | null = null;
+  private headsetJackPendingCount = 0;
+  private headsetAudioSwitchInFlight = false;
+  // Cache of active render endpoints (name + isBridge) from the last
+  // listRenderEndpoints() call -- used both for the settings dropdown and to
+  // auto-resolve the fallback when there's exactly one non-controller output.
+  private cachedRenderEndpoints: RenderEndpointInfo[] = [];
   private previousControllerConnected: boolean | null = null;
   private lowBatteryToastActive = false;
   private shortcutFeaturePollRetryAt = 0;
@@ -1748,6 +1771,10 @@ export class BridgeService extends EventEmitter {
     await setDefaultRenderBridgeEndpoint(mode);
   }
 
+  private async setDefaultRenderEndpointByName(candidateNames: string[]): Promise<void> {
+    await setDefaultRenderEndpointByName(candidateNames);
+  }
+
   private async defaultRenderIsBridgeEndpoint(): Promise<boolean> {
     const refresh = this.getDefaultRenderEndpointStatus()
       .then((status) => {
@@ -1988,6 +2015,7 @@ export class BridgeService extends EventEmitter {
     } catch {
       // Keep diagnostics best-effort so normal status polling is not blocked.
     }
+
   }
 
   private async readAudioDebugThrottled(force = false): Promise<void> {
@@ -2339,6 +2367,143 @@ export class BridgeService extends EventEmitter {
     }
     await this.applyControllerPowerSavingSensitiveSettings(settings, true);
     this.emitSnapshot();
+  }
+
+  // True while the interactive session is being remoted (RDP). Windows
+  // redirects audio to a "Remote Audio" endpoint then, and fighting that by
+  // forcing a default-render device is pointless and confusing -- mirrors the
+  // is_rdp_active() gate the user's C:\auto\boot automation already uses.
+  private isRemoteSessionActive(): boolean {
+    const sessionName = process.env.SESSIONNAME ?? '';
+    return /^rdp-/i.test(sessionName);
+  }
+
+  // Resolve the "jack empty" target device name: the explicitly chosen
+  // fallback if set, else -- when the last endpoint scan saw exactly one
+  // non-controller output -- that one, automatically. Returns '' if there is
+  // no usable target (feature then stays idle).
+  private resolveHeadsetAudioFallback(settings: CompanionSettings): string {
+    const explicit = settings.headsetAudioFallbackDevice.trim();
+    if (explicit !== '') {
+      return explicit;
+    }
+    const nonBridge = this.cachedRenderEndpoints.filter((endpoint) => !endpoint.isBridge);
+    return nonBridge.length === 1 ? nonBridge[0].name : '';
+  }
+
+  // "Auto Switch Audio on Jack". Called every poll with
+  // a fresh `this.audioStatus`. Debounces the raw jack bit, then drives the
+  // Windows default render endpoint: headset in jack -> the controller (bridge)
+  // endpoint; jack empty -> the resolved fallback device. Off entirely when
+  // the toggle is off or no fallback can be resolved. Never blocks the poll --
+  // the helper call is fire-and-forget with its own retry, and a switch
+  // already in flight is skipped.
+  private async syncHeadsetAudioAutoSwitch(settings: CompanionSettings): Promise<void> {
+    if (!settings.headsetAudioAutoSwitchEnabled) {
+      this.headsetJackActedState = null;
+      this.headsetJackPending = null;
+      this.headsetJackPendingCount = 0;
+      return;
+    }
+
+    if (
+      this.snapshot.state !== 'connected'
+      || this.audioStatus === null
+      || this.headsetAudioSwitchInFlight
+      || this.isRemoteSessionActive()
+      || this.isHostPersonaTransitionActive()
+      || this.hostPersonaDefaultRenderRestore !== null
+    ) {
+      return;
+    }
+
+    // With the toggle on but no explicit fallback chosen, we need the endpoint
+    // list to auto-resolve "the only other output". Refresh it once if we
+    // don't have it yet (first evaluation after connect / enable).
+    if (settings.headsetAudioFallbackDevice.trim() === '' && this.cachedRenderEndpoints.length === 0) {
+      this.cachedRenderEndpoints = await listRenderEndpoints();
+    }
+
+    const fallbackDevice = this.resolveHeadsetAudioFallback(settings);
+    if (fallbackDevice === '') {
+      // Toggle on but nothing usable to fall back to (0 or 2+ other outputs and
+      // no explicit pick). Stay idle without churning the acted-state.
+      return;
+    }
+
+    const jackPlugged = this.audioStatus.headsetPlugged;
+
+    // Debounce transitions only: a *changed* jack state must hold across N
+    // consecutive polls before we act. The very first evaluation after
+    // enable/connect (headsetJackActedState === null) is applied immediately
+    // -- there's no prior state to protect and the point is to correct
+    // whatever Windows currently has.
+    if (this.headsetJackPending === jackPlugged) {
+      this.headsetJackPendingCount += 1;
+    } else {
+      this.headsetJackPending = jackPlugged;
+      this.headsetJackPendingCount = 1;
+    }
+    if (
+      this.headsetJackActedState !== null
+      && this.headsetJackPendingCount < HEADSET_AUDIO_JACK_DEBOUNCE_POLLS
+    ) {
+      return;
+    }
+
+    if (this.headsetJackActedState === jackPlugged) {
+      // Already on the right target for this jack state -- but if the jack is
+      // empty and Windows has since made the controller default again, pull
+      // it back to the fallback.
+      if (!jackPlugged) {
+        await this.correctDefaultRenderIfBridgeWhileJackEmpty(fallbackDevice);
+      }
+      return;
+    }
+
+    this.headsetJackActedState = jackPlugged;
+    this.headsetAudioSwitchInFlight = true;
+    try {
+      if (jackPlugged) {
+        await this.setDefaultRenderBridgeEndpoint(settings.hostPersonaMode);
+        this.appendAudioDebugLines(['[AutoSwitchAudio] jack plugged -> default render = controller']);
+      } else {
+        await this.setDefaultRenderEndpointByName([fallbackDevice]);
+        this.appendAudioDebugLines([`[AutoSwitchAudio] jack empty -> default render = '${fallbackDevice}'`]);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.appendAudioDebugLines([`[AutoSwitchAudio] switch failed (jackPlugged=${jackPlugged}): ${message}`]);
+      // Let the next poll retry: clear the acted state so the transition is
+      // re-detected.
+      this.headsetJackActedState = null;
+    } finally {
+      this.headsetAudioSwitchInFlight = false;
+    }
+  }
+
+  private async correctDefaultRenderIfBridgeWhileJackEmpty(fallbackDevice: string): Promise<void> {
+    this.headsetAudioSwitchInFlight = true;
+    try {
+      const status = await this.getDefaultRenderEndpointStatus();
+      if (!status.isBridgeEndpoint) {
+        return;
+      }
+      await this.setDefaultRenderEndpointByName([fallbackDevice]);
+      this.appendAudioDebugLines([
+        `[AutoSwitchAudio] jack empty but controller was default -> forced '${fallbackDevice}'`
+      ]);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.appendAudioDebugLines([`[AutoSwitchAudio] empty-jack correction failed: ${message}`]);
+    } finally {
+      this.headsetAudioSwitchInFlight = false;
+    }
+  }
+
+  async listRenderEndpointNames(): Promise<RenderEndpointInfo[]> {
+    this.cachedRenderEndpoints = await listRenderEndpoints();
+    return this.cachedRenderEndpoints;
   }
 
   async setHapticsGain(percent: number): Promise<BridgeSnapshot> {
@@ -3028,6 +3193,32 @@ export class BridgeService extends EventEmitter {
     }
     this.emitSnapshot();
     return this.getSnapshot();
+  }
+
+  async setHeadsetAudioAutoSwitchEnabled(enabled: boolean): Promise<BridgeSnapshot> {
+    this.snapshot.settings = this.settingsStore.update({ headsetAudioAutoSwitchEnabled: enabled });
+    await this.reevaluateHeadsetAudioAutoSwitch();
+    return this.getSnapshot();
+  }
+
+  async setHeadsetAudioFallbackDevice(deviceName: string): Promise<BridgeSnapshot> {
+    this.snapshot.settings = this.settingsStore.update({
+      headsetAudioFallbackDevice: deviceName.trim()
+    });
+    await this.reevaluateHeadsetAudioAutoSwitch();
+    return this.getSnapshot();
+  }
+
+  private async reevaluateHeadsetAudioAutoSwitch(): Promise<void> {
+    // Force a fresh evaluation (adopt the current jack state and apply the
+    // matching target immediately, rather than waiting for the next poll).
+    this.headsetJackActedState = null;
+    this.headsetJackPending = null;
+    this.headsetJackPendingCount = 0;
+    if (this.snapshot.state === 'connected') {
+      await this.syncHeadsetAudioAutoSwitch(this.snapshot.settings);
+    }
+    this.emitSnapshot();
   }
 
   setUiScalePercent(value: UiScalePercent): BridgeSnapshot {
@@ -3797,6 +3988,7 @@ export class BridgeService extends EventEmitter {
     }
     await this.updateMicKeepaliveEngine(status.controllerConnected);
     await this.syncControllerPowerSavingState(settings);
+    await this.syncHeadsetAudioAutoSwitch(settings);
 
     if (status.controllerConnected) {
       this.controllerConnected = true;
@@ -4480,6 +4672,9 @@ export class BridgeService extends EventEmitter {
     this.feedbackTraceSupported = null;
     this.firmwareLogEnabled = null;
     this.controllerPowerSavingActive = null;
+    this.headsetJackActedState = null;
+    this.headsetJackPending = null;
+    this.headsetJackPendingCount = 0;
     this.systemAudioHapticsRetryAt = 0;
     this.systemAudioHapticsPassthroughActive = false;
     this.syncAudioHelperBridgeTarget();

--- a/companion/src/main/ipc-contract.test.ts
+++ b/companion/src/main/ipc-contract.test.ts
@@ -139,4 +139,16 @@ describe('IPC contract', () => {
     expect(mainSource).toContain("ipcMain.handle('bridge:setWakeOnConnectEnabled'");
     expect(bridgeServiceSource).toContain('setWakeOnConnectEnabled(enabled: boolean): Promise<BridgeSnapshot>');
   });
+
+  it('exposes the Auto Switch Audio on Jack preferences', () => {
+    expect(preloadSource).toContain("ipcRenderer.invoke('bridge:setHeadsetAudioAutoSwitchEnabled', value)");
+    expect(preloadSource).toContain("ipcRenderer.invoke('bridge:setHeadsetAudioFallbackDevice', value)");
+    expect(preloadSource).toContain("ipcRenderer.invoke('bridge:listRenderEndpointNames')");
+    expect(mainSource).toContain("ipcMain.handle('bridge:setHeadsetAudioAutoSwitchEnabled'");
+    expect(mainSource).toContain("ipcMain.handle('bridge:setHeadsetAudioFallbackDevice'");
+    expect(mainSource).toContain("ipcMain.handle('bridge:listRenderEndpointNames'");
+    expect(bridgeServiceSource).toContain('async setHeadsetAudioAutoSwitchEnabled(enabled: boolean): Promise<BridgeSnapshot>');
+    expect(bridgeServiceSource).toContain('async setHeadsetAudioFallbackDevice(deviceName: string): Promise<BridgeSnapshot>');
+    expect(bridgeServiceSource).toContain('async listRenderEndpointNames(): Promise<RenderEndpointInfo[]>');
+  });
 });

--- a/companion/src/main/main.ts
+++ b/companion/src/main/main.ts
@@ -1147,6 +1147,15 @@ function registerIpc(service: BridgeService): void {
   ipcMain.handle('bridge:setControllerPowerSavingEnabled', (_event, value: boolean) => (
     service.setControllerPowerSavingEnabled(value)
   ));
+  ipcMain.handle('bridge:setHeadsetAudioAutoSwitchEnabled', (_event, value: boolean) => (
+    service.setHeadsetAudioAutoSwitchEnabled(value)
+  ));
+  ipcMain.handle('bridge:setHeadsetAudioFallbackDevice', (_event, value: string) => (
+    service.setHeadsetAudioFallbackDevice(value)
+  ));
+  ipcMain.handle('bridge:listRenderEndpointNames', () => (
+    service.listRenderEndpointNames()
+  ));
   ipcMain.handle('bridge:setUiScalePercent', (_event, value: UiScalePercent) => {
     const snapshot = service.setUiScalePercent(value);
     applySnapshotWindowScale(snapshot);

--- a/companion/src/main/settings-store.ts
+++ b/companion/src/main/settings-store.ts
@@ -208,6 +208,10 @@ export const DEFAULT_SETTINGS: CompanionSettings = {
   notifyLowBattery: false,
   duplexMicEnabled: DEFAULT_CONTROLLER_PROFILE_SETTINGS.duplexMicEnabled,
   controllerPowerSavingEnabled: DEFAULT_CONTROLLER_PROFILE_SETTINGS.controllerPowerSavingEnabled,
+  // "Auto Switch Audio" off by default; empty fallback device = "use the only
+  // non-controller output" when there is exactly one.
+  headsetAudioAutoSwitchEnabled: false,
+  headsetAudioFallbackDevice: '',
   selectedControllerProfileId: DEFAULT_CONTROLLER_PROFILE_ID,
   controllerProfiles: [DEFAULT_CONTROLLER_PROFILE],
   selectedButtonRemappingProfileId: DEFAULT_BUTTON_REMAP_PROFILE_ID,
@@ -1059,6 +1063,12 @@ function normalizeSettings(value: Partial<CompanionSettings> | null | undefined)
     controllerPowerSavingEnabled: typeof value?.controllerPowerSavingEnabled === 'boolean'
       ? value.controllerPowerSavingEnabled
       : DEFAULT_SETTINGS.controllerPowerSavingEnabled,
+    headsetAudioAutoSwitchEnabled: typeof value?.headsetAudioAutoSwitchEnabled === 'boolean'
+      ? value.headsetAudioAutoSwitchEnabled
+      : DEFAULT_SETTINGS.headsetAudioAutoSwitchEnabled,
+    headsetAudioFallbackDevice: typeof value?.headsetAudioFallbackDevice === 'string'
+      ? value.headsetAudioFallbackDevice.trim()
+      : DEFAULT_SETTINGS.headsetAudioFallbackDevice,
     selectedControllerProfileId,
     controllerProfiles,
     selectedButtonRemappingProfileId,

--- a/companion/src/preload.ts
+++ b/companion/src/preload.ts
@@ -149,6 +149,15 @@ const api = {
   setControllerPowerSavingEnabled: (value: boolean): Promise<BridgeSnapshot> => (
     ipcRenderer.invoke('bridge:setControllerPowerSavingEnabled', value)
   ),
+  setHeadsetAudioAutoSwitchEnabled: (value: boolean): Promise<BridgeSnapshot> => (
+    ipcRenderer.invoke('bridge:setHeadsetAudioAutoSwitchEnabled', value)
+  ),
+  setHeadsetAudioFallbackDevice: (value: string): Promise<BridgeSnapshot> => (
+    ipcRenderer.invoke('bridge:setHeadsetAudioFallbackDevice', value)
+  ),
+  listRenderEndpointNames: (): Promise<Array<{ name: string; isBridge: boolean }>> => (
+    ipcRenderer.invoke('bridge:listRenderEndpointNames')
+  ),
   setLaunchAtStartupEnabled: (value: boolean): Promise<BridgeSnapshot> => (
     ipcRenderer.invoke('bridge:setLaunchAtStartupEnabled', value)
   ),

--- a/companion/src/renderer/App.tsx
+++ b/companion/src/renderer/App.tsx
@@ -3046,6 +3046,7 @@ export function App() {
   const [controllerDeviceForgetDialog, setControllerDeviceForgetDialog] = useState<ControllerDeviceForgetDialog | null>(null);
   const [controllerDeviceActionError, setControllerDeviceActionError] = useState<string | null>(null);
   const [showBridgeSettings, setShowBridgeSettings] = useState(false);
+  const [renderEndpoints, setRenderEndpoints] = useState<Array<{ name: string; isBridge: boolean }>>([]);
   const [settingsFocusTarget, setSettingsFocusTarget] = useState<SettingsFocusTarget | null>(null);
   const [notificationFocusTarget, setNotificationFocusTarget] = useState<NotificationFocusTarget | null>(null);
   const [showNotificationsMenu, setShowNotificationsMenu] = useState(false);
@@ -3650,6 +3651,30 @@ export function App() {
     };
   }, [showBridgeSettings, showNotificationsMenu]);
 
+  // Refresh the "Auto Switch Audio" fallback-device options whenever Bridge
+  // Settings opens -- the set of active Windows render endpoints changes as
+  // devices come and go.
+  useEffect(() => {
+    if (!showBridgeSettings) {
+      return;
+    }
+    let cancelled = false;
+    void window.bridge.listRenderEndpointNames()
+      .then((endpoints) => {
+        if (!cancelled) {
+          setRenderEndpoints(endpoints);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setRenderEndpoints([]);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [showBridgeSettings]);
+
   useEffect(() => {
     setSpeakerOutputAvailable(true);
   }, []);
@@ -3888,6 +3913,33 @@ export function App() {
   const adaptiveTriggerOutputActive = Boolean(snapshot?.status?.adaptiveTriggerOutputRecent);
   const audioStatus = snapshot?.diagnostics.audioStatus;
   const headsetOutputDetected = Boolean(audioStatus?.headsetPlugged);
+  const headsetAudioAutoSwitchEnabled = Boolean(snapshot?.settings.headsetAudioAutoSwitchEnabled);
+  const headsetAudioFallbackDevice = snapshot?.settings.headsetAudioFallbackDevice ?? '';
+  // Real output devices = everything except the controller's own endpoint.
+  const headsetAudioOutputChoices = useMemo(
+    () => renderEndpoints.filter((endpoint) => !endpoint.isBridge).map((endpoint) => endpoint.name),
+    [renderEndpoints]
+  );
+  // Show the fallback dropdown only when the choice is ambiguous (2+ real
+  // outputs). With exactly one, the firmware auto-uses it; with none detected
+  // yet, there's nothing to pick.
+  const headsetAudioShowFallbackSelect = headsetAudioOutputChoices.length >= 2
+    || (headsetAudioFallbackDevice !== '' && !headsetAudioOutputChoices.includes(headsetAudioFallbackDevice));
+  const headsetAudioFallbackOptions = useMemo<Array<[string, string]>>(() => {
+    const options: Array<[string, string]> = [['Auto (only other output)', '']];
+    for (const name of headsetAudioOutputChoices) {
+      options.push([name, name]);
+    }
+    // Keep a previously-saved device selectable even when it isn't currently
+    // present (its device is off), so the choice survives a power cycle.
+    if (
+      headsetAudioFallbackDevice !== ''
+      && !headsetAudioOutputChoices.includes(headsetAudioFallbackDevice)
+    ) {
+      options.push([`${headsetAudioFallbackDevice} (not connected)`, headsetAudioFallbackDevice]);
+    }
+    return options;
+  }, [headsetAudioOutputChoices, headsetAudioFallbackDevice]);
   const controllerPowerSavingActive = controllerPowerSavingActiveFromSnapshot(snapshot);
   const feedbackBoostEnabled = Boolean(snapshot?.settings.feedbackBoostEnabled);
   const hapticsSliderMax = feedbackSliderMaxFromSnapshot(snapshot);
@@ -10550,6 +10602,56 @@ export function App() {
                   >
                     <span />
                   </button>
+                </div>
+                <div className="settings-menu-row">
+                  <div className="settings-menu-copy">
+                    <strong>Auto Switch Audio on Jack</strong>
+                    <span>Switches Windows output to the controller when a headset is plugged in, and back on disconnect.</span>
+                  </div>
+                  {headsetAudioShowFallbackSelect ? (
+                    <div className="settings-menu-controls headset-audio-controls">
+                      <CustomSelect
+                        value={headsetAudioFallbackDevice}
+                        options={headsetAudioFallbackOptions}
+                        className="headset-audio-fallback-select"
+                        showSelectedCheck={false}
+                        floatingMenu
+                        floatingMenuMinWidth={320}
+                        ariaLabel="Return audio to this device when the headset is unplugged"
+                        disabled={pendingAction !== null || !headsetAudioAutoSwitchEnabled}
+                        onChange={(value) => {
+                          void runAction('headset-audio-fallback', () => (
+                            window.bridge.setHeadsetAudioFallbackDevice(value)
+                          ));
+                        }}
+                      />
+                      <button
+                        type="button"
+                        role="switch"
+                        aria-checked={headsetAudioAutoSwitchEnabled}
+                        className={`switch ${headsetAudioAutoSwitchEnabled ? 'on' : ''}`}
+                        disabled={pendingAction !== null}
+                        onClick={() => void runAction('headset-audio-auto-switch', () => (
+                          window.bridge.setHeadsetAudioAutoSwitchEnabled(!headsetAudioAutoSwitchEnabled)
+                        ))}
+                      >
+                        <span />
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      type="button"
+                      role="switch"
+                      aria-checked={headsetAudioAutoSwitchEnabled}
+                      className={`switch ${headsetAudioAutoSwitchEnabled ? 'on' : ''}`}
+                      disabled={pendingAction !== null}
+                      onClick={() => void runAction('headset-audio-auto-switch', () => (
+                        window.bridge.setHeadsetAudioAutoSwitchEnabled(!headsetAudioAutoSwitchEnabled)
+                      ))}
+                    >
+                      <span />
+                    </button>
+                  )}
                 </div>
                 <div className="settings-menu-row">
                   <div className="settings-menu-copy">

--- a/companion/src/renderer/styles.css
+++ b/companion/src/renderer/styles.css
@@ -2407,6 +2407,47 @@ button {
   flex: 0 0 86px;
 }
 
+/* "Auto Switch Audio on Jack": when there are 2+ real outputs to choose
+   between, the controls are [ fallback select ] + [ toggle ] as a flex group
+   flush to the right edge (same shape as Idle Disconnect). When there's 0 or
+   1 other output the select isn't rendered at all and the bare toggle sits
+   flush right like every other toggle row. The select's dropdown menu opens
+   wider than the button (floatingMenu + floatingMenuMinWidth) so long Windows
+   endpoint names are fully legible. */
+.headset-audio-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 0 0 auto;
+}
+
+.headset-audio-fallback-select {
+  flex: 0 1 200px;
+  min-width: 0;
+}
+
+.headset-audio-fallback-select .custom-select-button {
+  height: 26px;
+  padding: 0 7px 0 9px;
+  grid-template-columns: minmax(0, 1fr) 16px;
+  gap: 4px;
+  font-size: 12px;
+  font-weight: 750;
+}
+
+.headset-audio-fallback-select .custom-select-button svg {
+  width: 14px;
+  height: 14px;
+}
+
+.headset-audio-fallback-select .custom-select-menu button {
+  min-height: 26px;
+  padding: 0 10px;
+  font-size: 12px;
+  font-weight: 650;
+  white-space: nowrap;
+}
+
 .settings-scale-select .custom-select-button {
   height: 26px;
   padding: 0 7px 0 9px;

--- a/companion/src/shared/protocol.test.ts
+++ b/companion/src/shared/protocol.test.ts
@@ -372,6 +372,7 @@ describe('companion protocol', () => {
     });
   });
 
+
   it('parses a trigger trace report', () => {
     const report = baseReport(REPORT_ID.TRIGGER_TRACE);
     report[7] = 1;

--- a/companion/src/shared/protocol.ts
+++ b/companion/src/shared/protocol.ts
@@ -578,6 +578,7 @@ export interface AudioDebugStatsPayload {
   criticalStarvingAudioCount: number;
 }
 
+
 export interface TriggerTraceEventPayload {
   sequence: number;
   timeMs: number;
@@ -974,6 +975,7 @@ export function parseAudioStatsReport(report: ArrayLike<number>): AudioDebugStat
     criticalStarvingAudioCount: readU32(report, 60)
   };
 }
+
 
 export function parseTriggerTraceReport(report: ArrayLike<number>): TriggerTracePayload {
   assertReport(report, REPORT_ID.TRIGGER_TRACE);

--- a/companion/src/shared/types.ts
+++ b/companion/src/shared/types.ts
@@ -90,6 +90,12 @@ export interface CompanionSettings {
   notifyLowBattery: boolean;
   duplexMicEnabled: boolean;
   controllerPowerSavingEnabled: boolean;
+  // "Auto Switch Audio": when on, a headset in the controller's 3.5 mm jack
+  // makes the controller the Windows default output; jack empty routes back to
+  // `headsetAudioFallbackDevice`. When that name is empty and exactly one
+  // non-controller output exists, that one is used automatically.
+  headsetAudioAutoSwitchEnabled: boolean;
+  headsetAudioFallbackDevice: string;
   selectedControllerProfileId: string;
   controllerProfiles: ControllerProfile[];
   selectedButtonRemappingProfileId: string;


### PR DESCRIPTION
## Problem

The DualSense's audio endpoint stays present in Windows whether or not
anything is plugged into the controller's 3.5 mm jack. Windows frequently
promotes it to the default output device when the controller connects, so
system audio goes to the controller's speaker even with no headset attached.

Windows cannot detect the jack state itself -- the USB audio device does not
disconnect when the headset is unplugged -- so it cannot switch back on its
own. Users have to change the default output manually every time.

## Change

Companion-app only. The firmware already reports the jack state: the
DualSense input report's `PluggedHeadphones` bit reaches the companion as
`audioStatus.headsetPlugged`. **No firmware change is required.**

When enabled, the companion drives the Windows default render endpoint:

- Headset in the controller's jack -> the controller / bridge endpoint.
- Jack empty -> a fallback output device.

The fallback is chosen in Bridge Settings. When exactly one non-controller
output exists it is used automatically and no dropdown is shown; with two or
more, a dropdown lists them. This also covers the case where Windows promotes
the controller to default while the jack is empty -- the companion routes
back to the fallback.

### Details

- **Debounce.** The firmware bit is an unfiltered pass-through of the input
  report with no debouncing, so a marginal plug can chatter. A changed jack
  state must hold across two consecutive audio-status polls (~1 s) before the
  companion acts.
- **Bit 0, not bit 1.** `headsetAudioRoute` (bit 1) reflects
  firmware-internal speaker routing and is false whenever nothing is playing.
  `headsetPlugged` (bit 0) is the actual jack state.
- **Dormant during RDP.** Windows redirects audio to a Remote Audio endpoint
  during a remote session; the feature stays inactive rather than fighting
  it.
- **Dormant during host-persona transitions** and while the existing persona
  default-render restore is in flight.
- Off by default. Enabling requires the toggle and takes effect only when a
  fallback device can be resolved.

### Implementation

- `companion/native/AudioHelper` -- two new verbs:
  `--set-default-render --device-name "A;B;C"` (set the default render
  endpoint to the first active match; reuses the existing
  `IPolicyConfig::SetDefaultEndpoint` path) and `--list-render-endpoints`
  (active render endpoints as JSON, flagging the bridge's own endpoint).
- `bridge-service.ts` -- `syncHeadsetAudioAutoSwitch()`, called once per poll
  after `syncControllerPowerSavingState()`.
- Two settings: `headsetAudioAutoSwitchEnabled` (bool) and
  `headsetAudioFallbackDevice` (string; empty means auto-resolve).
- Three IPC channels, one settings row in Bridge Settings.

No `COMMAND_ID`, no `PROTOCOL_MINOR` bump, no firmware change.

### Settings modal size

This adds one row to Bridge Settings. The preferences modal is already the
tightest variant, and on a fresh checkout the Power & Controller column can
get crowded. This is a UI-layout call for the maintainer and is **not**
changed in this PR. Our suggestion, if a change is wanted, is to let the
preferences modal fill the app window (the two columns then fit without an
internal scrollbar); a smaller height bump would also work.

## Testing

`npm run typecheck` and `npx vitest run src` pass. Seven new tests cover the
plug/unplug transitions with debounce, the disabled case, auto-resolution of
a single output, the ambiguous multi-output case, the empty-jack correction,
RDP dormancy, and the IPC contract. `npm run build:audio-helper` builds
clean.

Hardware (Waveshare RP2350B-Plus-W, Windows 11):

1. Controller connects with an empty jack, Windows promotes it to default --
   output is routed back to the fallback device.
2. Headset plugged in -- output switches to the controller within ~1 s.
3. Unplugged -- output returns to the fallback.
4. Feature disabled -- neither switch occurs.
5. Repeated partial insertions -- no flip-flopping.
6. Two-plus non-controller outputs present -- the dropdown lists them, the
   selected fallback persists, and a saved-but-absent device shows
   "(not connected)".
